### PR TITLE
Add INDIGO//97 to the mod gallery

### DIFF
--- a/mods/examples/indigo_97/.modkitignore
+++ b/mods/examples/indigo_97/.modkitignore
@@ -1,0 +1,2 @@
+tests/indigo_97_test.lua
+

--- a/mods/examples/indigo_97/CHANGELOG.md
+++ b/mods/examples/indigo_97/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 1.2.1 - 2026-08-21
+
+### Fixed
+
+- Gold and Silver now recolour the shared `gen2_fish_*` pose strips emitted by
+  their ROM importer. Crystal keeps using its per-character Chris and Kris
+  pose strips.
+- Crystal now recolours the actual `krisbike.png` bicycle sheet emitted by its
+  ROM importer.
+- Kris's front-facing red suspenders begin on her torso instead of touching
+  her cheeks like red tears in the enlarged voxel view.
+
+### Verified
+
+- Full imports of canonical personal Pokemon Gold, Silver and Crystal ROMs
+  through Gen2Recomped's in-app importer, followed by mod-transform and live
+  renderer checks for each game's real asset paths.
+
 ## 1.2.0 - 2026-08-21
 
 ### Added

--- a/mods/examples/indigo_97/CHANGELOG.md
+++ b/mods/examples/indigo_97/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 1.2.0 - 2026-08-21
+
+### Added
+
+- Matching true-colour fishing poses for the boy player in Gold, Silver and
+  Crystal.
+- Matching true-colour fishing poses for the Crystal heroine.
+
+### Preserved
+
+- Boy and Crystal heroine walking and bicycle output from earlier releases.
+- Trainer-card portraits and battle portraits remain unchanged.
+
 ## 1.1.0 - 2026-08-20
 
 ### Added
@@ -24,4 +37,3 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - ROM-safe first-load transform; no extracted game artwork is distributed.
 - Optional Voxel Characters integration and recommended visual settings.
 - GitHub update metadata and automated installable release packaging.
-

--- a/mods/examples/indigo_97/CHANGELOG.md
+++ b/mods/examples/indigo_97/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## 1.0.0 - 2026-08-20
+
+### Added
+
+- Late-1990s anime-inspired true-colour treatment for the Gen 2 boy player.
+- Walking and bicycle support across Gold, Silver and the boy route in Crystal.
+- ROM-safe first-load transform; no extracted game artwork is distributed.
+- Optional Voxel Characters integration and recommended visual settings.
+- GitHub update metadata and automated installable release packaging.
+

--- a/mods/examples/indigo_97/CHANGELOG.md
+++ b/mods/examples/indigo_97/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 1.1.0 - 2026-08-20
+
+### Added
+
+- Cerulean-era anime-inspired true-colour treatment for the Crystal heroine.
+- Crystal heroine walking and bicycle support, including orange hair, a yellow
+  top, red accents, denim-blue shorts and a teal backpack.
+
+### Preserved
+
+- The 1.0.0 boy-player transform is pixel-identical in 1.1.0.
+- Fishing poses, trainer-card portraits and battle portraits remain unchanged.
+
 ## 1.0.0 - 2026-08-20
 
 ### Added

--- a/mods/examples/indigo_97/LICENSE.md
+++ b/mods/examples/indigo_97/LICENSE.md
@@ -1,0 +1,27 @@
+MIT License
+
+Copyright (c) 2026 n47h4ni3l
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Pokémon and the underlying game artwork are the property of their respective
+owners. No ownership of those elements is claimed. This repository distributes
+only code and colour-design instructions; it contains no ROM or extracted game
+artwork.
+

--- a/mods/examples/indigo_97/README.md
+++ b/mods/examples/indigo_97/README.md
@@ -4,9 +4,6 @@ INDIGO//97 gives both Gen 2 player characters late-1990s anime-inspired
 true-colour overworld designs while preserving the cartridge's original
 animation timing.
 
-**Persona: the broadcast colourist.** It treats the compact cartridge sprite
-like a character cel from a late-1990s Saturday-morning adventure.
-
 Red-and-white cap. Dark hair. Blue jacket. Green gloves and backpack. Pale
 jeans. Red trainers. It is deliberately vivid enough to belong in Dramatic
 Shape's diorama world without losing the chunky 16-pixel character language.
@@ -15,14 +12,6 @@ Crystal's heroine gets a complementary Cerulean-era design: orange hair with
 auburn shading, a yellow top with red accents, denim-blue shorts, red shoes and
 a teal backpack. Her original silhouette and all six animation frames remain
 intact.
-
-## Try it
-
-```sh
-python3 tools/modkit.py validate mods/examples/indigo_97 --base imported
-python3 tools/modkit.py lint mods/examples/indigo_97
-luajit mods/examples/indigo_97/tests/indigo_97_test.lua
-```
 
 ## Install
 
@@ -36,8 +25,8 @@ versions from the mod manager.
 ## Recommended pairing
 
 INDIGO//97 works as a flat true-colour sprite by itself. Install **Voxel
-Characters 1.8.1 or newer** for the block-built depth shown in the release
-screenshots. Dramatic Shape is optional and changes the world rather than this
+Characters 1.8.1 or newer** for the block-built depth used during Steam Deck
+testing. Dramatic Shape is optional and changes the world rather than this
 mod's colours.
 
 Suggested Voxel Characters settings:
@@ -58,7 +47,7 @@ Suggested Voxel Characters settings:
 - Crystal heroine fishing poses.
 - Colour only: movement, collision, saves and game data are untouched.
 
-Trainer-card portraits and battle portraits are not changed in 1.2.0.
+Trainer-card portraits and battle portraits are not changed in 1.2.1.
 
 ## ROM-safe by design
 

--- a/mods/examples/indigo_97/README.md
+++ b/mods/examples/indigo_97/README.md
@@ -1,7 +1,8 @@
 # INDIGO//97
 
-INDIGO//97 gives the Gen 2 boy player a late-1990s anime-inspired true-colour
-overworld design while preserving the cartridge's original animation timing.
+INDIGO//97 gives both Gen 2 player characters late-1990s anime-inspired
+true-colour overworld designs while preserving the cartridge's original
+animation timing.
 
 **Persona: the broadcast colourist.** It treats the compact cartridge sprite
 like a character cel from a late-1990s Saturday-morning adventure.
@@ -9,6 +10,11 @@ like a character cel from a late-1990s Saturday-morning adventure.
 Red-and-white cap. Dark hair. Blue jacket. Green gloves and backpack. Pale
 jeans. Red trainers. It is deliberately vivid enough to belong in Dramatic
 Shape's diorama world without losing the chunky 16-pixel character language.
+
+Crystal's heroine gets a complementary Cerulean-era design: orange hair with
+auburn shading, a yellow top with red accents, denim-blue shorts, red shoes and
+a teal backpack. Her original silhouette and all six animation frames remain
+intact.
 
 ## Try it
 
@@ -46,10 +52,12 @@ Suggested Voxel Characters settings:
 
 - Boy-player walking frames in Gold, Silver and Crystal.
 - Boy-player bicycle frames in Gold, Silver and Crystal.
+- Crystal heroine walking frames.
+- Crystal heroine bicycle frames.
 - Colour only: movement, collision, saves and game data are untouched.
 
-The Crystal girl, fishing poses, trainer-card portrait and battle portrait are
-not changed in 1.0.0.
+Fishing poses, trainer-card portraits and battle portraits are not changed in
+1.1.0.
 
 ## ROM-safe by design
 
@@ -66,13 +74,12 @@ run again.
 
 - Gen2Recomped `0.7.6` through the last `0.x` release.
 - Mod API 2.
-- Designed to compose with Voxel Characters 1.8.1+.
-- Conflicts with the earlier private `retro_anime_trainer` prototype; keep only
-  one enabled.
+- Designed to compose with Voxel Characters 1.8.1+ but is still optimised as a
+  stand-alone.
 
 ## Credits
 
-- **n47h4ni3l**: concept, art direction and Steam Deck field testing.
+- **n47h4ni3l**: concept, art direction and testing.
 - **OpenAI Codex**: implementation and packaging assistance.
 - **Gen2Recomped contributors**: mod API, asset-transform system and tooling.
 

--- a/mods/examples/indigo_97/README.md
+++ b/mods/examples/indigo_97/README.md
@@ -54,10 +54,11 @@ Suggested Voxel Characters settings:
 - Boy-player bicycle frames in Gold, Silver and Crystal.
 - Crystal heroine walking frames.
 - Crystal heroine bicycle frames.
+- Boy-player fishing poses in Gold, Silver and Crystal.
+- Crystal heroine fishing poses.
 - Colour only: movement, collision, saves and game data are untouched.
 
-Fishing poses, trainer-card portraits and battle portraits are not changed in
-1.1.0.
+Trainer-card portraits and battle portraits are not changed in 1.2.0.
 
 ## ROM-safe by design
 
@@ -86,4 +87,3 @@ run again.
 INDIGO//97 is an unofficial fan-made mod. Pokémon and the underlying game
 artwork belong to their respective owners. A legally obtained compatible ROM
 and Gen2Recomped are required; neither is distributed here.
-

--- a/mods/examples/indigo_97/README.md
+++ b/mods/examples/indigo_97/README.md
@@ -1,0 +1,82 @@
+# INDIGO//97
+
+INDIGO//97 gives the Gen 2 boy player a late-1990s anime-inspired true-colour
+overworld design while preserving the cartridge's original animation timing.
+
+**Persona: the broadcast colourist.** It treats the compact cartridge sprite
+like a character cel from a late-1990s Saturday-morning adventure.
+
+Red-and-white cap. Dark hair. Blue jacket. Green gloves and backpack. Pale
+jeans. Red trainers. It is deliberately vivid enough to belong in Dramatic
+Shape's diorama world without losing the chunky 16-pixel character language.
+
+## Try it
+
+```sh
+python3 tools/modkit.py validate mods/examples/indigo_97 --base imported
+python3 tools/modkit.py lint mods/examples/indigo_97
+luajit mods/examples/indigo_97/tests/indigo_97_test.lua
+```
+
+## Install
+
+1. Download the `.zip` from the latest GitHub release. Keep it zipped.
+2. Open Gen2Recomped and choose **MODS > Import mod .zip**.
+3. Enable **INDIGO//97** and restart when prompted.
+
+That is all. Once installed, Gen2Recomped can check this repository for future
+versions from the mod manager.
+
+## Recommended pairing
+
+INDIGO//97 works as a flat true-colour sprite by itself. Install **Voxel
+Characters 1.8.1 or newer** for the block-built depth shown in the release
+screenshots. Dramatic Shape is optional and changes the world rather than this
+mod's colours.
+
+Suggested Voxel Characters settings:
+
+- `STATUS`: `ACTIVE`
+- `VOXEL CHARS`: `3`
+- `SHAPE`: `CARVED+`
+- `GROUND SHADE`: `ON`
+- `BREATH`: `SUBTLE`
+
+## What it changes
+
+- Boy-player walking frames in Gold, Silver and Crystal.
+- Boy-player bicycle frames in Gold, Silver and Crystal.
+- Colour only: movement, collision, saves and game data are untouched.
+
+The Crystal girl, fishing poses, trainer-card portrait and battle portrait are
+not changed in 1.0.0.
+
+## ROM-safe by design
+
+No ROM, extracted sprite sheet or cartridge-derived image is included. On first
+load, `transforms.lua` reads the player sprites already created from your own
+imported ROM, applies INDIGO//97's colour design, and writes private derived
+copies inside your Gen2Recomped save directory.
+
+Disable the mod to restore the cartridge appearance. Delete
+`save/mod-derived/indigo_97` if you ever want to force the colour transform to
+run again.
+
+## Compatibility
+
+- Gen2Recomped `0.7.6` through the last `0.x` release.
+- Mod API 2.
+- Designed to compose with Voxel Characters 1.8.1+.
+- Conflicts with the earlier private `retro_anime_trainer` prototype; keep only
+  one enabled.
+
+## Credits
+
+- **n47h4ni3l**: concept, art direction and Steam Deck field testing.
+- **OpenAI Codex**: implementation and packaging assistance.
+- **Gen2Recomped contributors**: mod API, asset-transform system and tooling.
+
+INDIGO//97 is an unofficial fan-made mod. Pokémon and the underlying game
+artwork belong to their respective owners. A legally obtained compatible ROM
+and Gen2Recomped are required; neither is distributed here.
+

--- a/mods/examples/indigo_97/main.lua
+++ b/mods/examples/indigo_97/main.lua
@@ -1,0 +1,17 @@
+-- INDIGO//97
+--
+-- transforms.lua writes full-colour versions of the player's own imported
+-- sheets under save/mod-derived/indigo_97. Keeping the original image paths
+-- lets the asset resolver select those derived copies automatically.
+return function(mod)
+  for _, id in ipairs({ "SPRITE_RED", "SPRITE_RED_BIKE" }) do
+    if mod.content.sprites:get(id) then
+      -- Patch only the colour contract. Image, frame count, walker metadata
+      -- and ROM-hack-specific fields remain whatever the merged game supplied.
+      mod.content.sprites:patch(id, { trueColor = true })
+    else
+      mod.log:warn("%s is unavailable; import a supported Gen 2 ROM and reload", id)
+    end
+  end
+end
+

--- a/mods/examples/indigo_97/main.lua
+++ b/mods/examples/indigo_97/main.lua
@@ -4,13 +4,21 @@
 -- sheets under save/mod-derived/indigo_97. Keeping the original image paths
 -- lets the asset resolver select those derived copies automatically.
 return function(mod)
-  for _, id in ipairs({ "SPRITE_RED", "SPRITE_RED_BIKE" }) do
-    if mod.content.sprites:get(id) then
+  local sprites = {
+    { id = "SPRITE_RED", required = true },
+    { id = "SPRITE_RED_BIKE", required = true },
+    { id = "SPRITE_KRIS", required = false },
+    { id = "SPRITE_KRIS_BIKE", required = false },
+  }
+
+  for _, sprite in ipairs(sprites) do
+    if mod.content.sprites:get(sprite.id) then
       -- Patch only the colour contract. Image, frame count, walker metadata
       -- and ROM-hack-specific fields remain whatever the merged game supplied.
-      mod.content.sprites:patch(id, { trueColor = true })
-    else
-      mod.log:warn("%s is unavailable; import a supported Gen 2 ROM and reload", id)
+      mod.content.sprites:patch(sprite.id, { trueColor = true })
+    elseif sprite.required then
+      mod.log:warn("%s is unavailable; import a supported Gen 2 ROM and reload",
+        sprite.id)
     end
   end
 end

--- a/mods/examples/indigo_97/manifest.json
+++ b/mods/examples/indigo_97/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "indigo_97",
   "name": "INDIGO//97",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "api": 2,
   "games": ["gen2"],
   "entry": "main.lua",

--- a/mods/examples/indigo_97/manifest.json
+++ b/mods/examples/indigo_97/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "indigo_97",
   "name": "INDIGO//97",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "api": 2,
   "games": ["gen2"],
   "entry": "main.lua",
@@ -16,6 +16,5 @@
   "incompatible": [],
   "experimental": false,
   "github": "n47h4ni3l/gen2recomp-indigo97",
-  "description": "Late-1990s anime-inspired true-colour boy and Crystal heroine designs for Gen2Recomped. Pair with Voxel Characters for depth."
+  "description": "Late-1990s anime-inspired true-colour player designs and fishing poses for Gen2Recomped. Pair with Voxel Characters for depth."
 }
-

--- a/mods/examples/indigo_97/manifest.json
+++ b/mods/examples/indigo_97/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "indigo_97",
+  "name": "INDIGO//97",
+  "version": "1.0.0",
+  "api": 2,
+  "games": ["gen2"],
+  "entry": "main.lua",
+  "profile": "content",
+  "game_version": ">=0.7.6 <1.0.0",
+  "category": "GRAPHICS",
+  "priority": 200,
+  "assets_transforms": "transforms.lua",
+  "dependencies": [],
+  "optional_dependencies": ["voxel_characters"],
+  "conflicts": ["retro_anime_trainer"],
+  "incompatible": [],
+  "experimental": false,
+  "github": "n47h4ni3l/gen2recomp-indigo97",
+  "description": "A late-1990s anime-inspired true-colour boy trainer for Gen2Recomped. Pair with Voxel Characters for block-built depth."
+}
+

--- a/mods/examples/indigo_97/manifest.json
+++ b/mods/examples/indigo_97/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "indigo_97",
   "name": "INDIGO//97",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "api": 2,
   "games": ["gen2"],
   "entry": "main.lua",
@@ -16,6 +16,6 @@
   "incompatible": [],
   "experimental": false,
   "github": "n47h4ni3l/gen2recomp-indigo97",
-  "description": "A late-1990s anime-inspired true-colour boy trainer for Gen2Recomped. Pair with Voxel Characters for block-built depth."
+  "description": "Late-1990s anime-inspired true-colour boy and Crystal heroine designs for Gen2Recomped. Pair with Voxel Characters for depth."
 }
 

--- a/mods/examples/indigo_97/mod.card
+++ b/mods/examples/indigo_97/mod.card
@@ -9,12 +9,13 @@ return {
       "boy-player walking and bicycle sheets receive the INDIGO//97 colour design",
       "SPRITE_KRIS and SPRITE_KRIS_BIKE render as true-colour art",
       "Crystal heroine walking and bicycle sheets receive a Cerulean-era colour design",
+      "boy and Crystal heroine fishing poses match their INDIGO//97 designs",
     },
     added = {
       "a first-load asset transform that writes only to save/mod-derived/indigo_97",
     },
     known = {
-      "fishing poses, trainer-card portraits and battle portraits are unchanged",
+      "trainer-card portraits and battle portraits are unchanged",
       "Voxel Characters is optional and required only for block-built depth",
     },
   },
@@ -25,4 +26,3 @@ return {
   },
   compat = { engine = ">=0.7.6 <1.0.0", modApi = 2 },
 }
-

--- a/mods/examples/indigo_97/mod.card
+++ b/mods/examples/indigo_97/mod.card
@@ -1,0 +1,26 @@
+return {
+  summary = "Late-90s anime colour for the Gen 2 boy player, generated from your own ROM cache.",
+  author = "n47h4ni3l",
+  contact = "https://github.com/n47h4ni3l/gen2recomp-indigo97",
+  tags = { "cosmetic", "graphics", "gen2" },
+  differences = {
+    changed = {
+      "SPRITE_RED and SPRITE_RED_BIKE render as true-colour art",
+      "boy-player walking and bicycle sheets receive the INDIGO//97 colour design",
+    },
+    added = {
+      "a first-load asset transform that writes only to save/mod-derived/indigo_97",
+    },
+    known = {
+      "the Crystal girl, fishing poses, trainer-card portrait and battle portrait are unchanged",
+      "Voxel Characters is optional and required only for block-built depth",
+    },
+  },
+  credits = {
+    { who = "n47h4ni3l", for_ = "concept, art direction and Steam Deck field testing" },
+    { who = "OpenAI Codex", for_ = "implementation and packaging assistance" },
+    { who = "Gen2Recomped contributors", for_ = "mod API, asset-transform system and tooling" },
+  },
+  compat = { engine = ">=0.7.6 <1.0.0", modApi = 2 },
+}
+

--- a/mods/examples/indigo_97/mod.card
+++ b/mods/examples/indigo_97/mod.card
@@ -1,5 +1,5 @@
 return {
-  summary = "Late-90s anime colour for the Gen 2 boy player, generated from your own ROM cache.",
+  summary = "Late-90s anime colour for both Gen 2 player characters, generated from your ROM cache.",
   author = "n47h4ni3l",
   contact = "https://github.com/n47h4ni3l/gen2recomp-indigo97",
   tags = { "cosmetic", "graphics", "gen2" },
@@ -7,17 +7,19 @@ return {
     changed = {
       "SPRITE_RED and SPRITE_RED_BIKE render as true-colour art",
       "boy-player walking and bicycle sheets receive the INDIGO//97 colour design",
+      "SPRITE_KRIS and SPRITE_KRIS_BIKE render as true-colour art",
+      "Crystal heroine walking and bicycle sheets receive a Cerulean-era colour design",
     },
     added = {
       "a first-load asset transform that writes only to save/mod-derived/indigo_97",
     },
     known = {
-      "the Crystal girl, fishing poses, trainer-card portrait and battle portrait are unchanged",
+      "fishing poses, trainer-card portraits and battle portraits are unchanged",
       "Voxel Characters is optional and required only for block-built depth",
     },
   },
   credits = {
-    { who = "n47h4ni3l", for_ = "concept, art direction and Steam Deck field testing" },
+    { who = "n47h4ni3l", for_ = "concept, art direction and testing" },
     { who = "OpenAI Codex", for_ = "implementation and packaging assistance" },
     { who = "Gen2Recomped contributors", for_ = "mod API, asset-transform system and tooling" },
   },

--- a/mods/examples/indigo_97/tests/indigo_97_test.lua
+++ b/mods/examples/indigo_97/tests/indigo_97_test.lua
@@ -101,13 +101,29 @@ local function sourceSheet()
   return image
 end
 
+local function sourceFishingPose()
+  local image = fakeImage(16, 8, { 1, 1, 1, 1 })
+  -- A compact lower-body/rod pose: opaque shades exercise face, outfit,
+  -- glove, trouser and shoe regions without embedding cartridge artwork.
+  for y = 0, 7 do
+    for x = 3, 12 do
+      local edge = x == 3 or x == 12 or y == 7
+      local shade = edge and 0 or (y % 2 == 0 and 1 / 3 or 2 / 3)
+      image:setPixel(x, y, shade, shade, shade, 1)
+    end
+  end
+  return image
+end
+
 local transform = assert(loadfile(MOD .. "/transforms.lua"))()
 T.check(type(transform) == "function", "transforms.lua returns function(ctx)")
 
 local written = {}
 local ok, err = pcall(transform, {
   exists = function() return true end,
-  readImage = function() return sourceSheet() end,
+  readImage = function(rel)
+    return rel:sub(1, 3) == "fx/" and sourceFishingPose() or sourceSheet()
+  end,
   blank = function(w, h) return fakeImage(w, h) end,
   writeImage = function(image, rel) written[rel] = image end,
 })
@@ -117,6 +133,13 @@ T.check(written["sprites/chrisbike.png"] ~= nil, "writes the bicycle sheet")
 T.check(written["sprites/kris.png"] ~= nil, "writes the Crystal walking sheet")
 T.check(written["sprites/kris_bike.png"] ~= nil,
   "writes the Crystal bicycle sheet")
+for _, rel in ipairs({
+    "fx/chris_fish_down.png", "fx/chris_fish_up.png",
+    "fx/chris_fish_side.png", "fx/kris_fish_down.png",
+    "fx/kris_fish_up.png", "fx/kris_fish_side.png",
+  }) do
+  T.check(written[rel] ~= nil, "writes " .. rel)
+end
 
 local walk = written["sprites/chris.png"]
 local _, _, _, transparent = walk:getPixel(0, 0)
@@ -168,6 +191,35 @@ T.check(er > eg and er > eb, "Crystal heroine receives red shoes")
 local tr, tg, tb = girl:getPixel(7, 16 + 10)
 T.check(tg > tb and tb > tr, "Crystal heroine receives a teal backpack")
 
+local boyFish = written["fx/chris_fish_down.png"]
+local bfr, bfg, bfb = boyFish:getPixel(6, 3)
+T.check(bfb > bfg and bfg > bfr,
+  "boy fishing pose receives the blue jacket treatment")
+local bsr, bsg, bsb = boyFish:getPixel(6, 5)
+T.check(bsb > bsg and bsg > bsr,
+  "boy fishing pose receives pale trouser shading")
+local girlFish = written["fx/kris_fish_down.png"]
+local gyr, gyg, gyb = girlFish:getPixel(6, 3)
+T.check(gyr > gyg and gyg > gyb,
+  "Crystal heroine fishing pose receives the yellow top treatment")
+local gdr, gdg, gdb = girlFish:getPixel(6, 5)
+T.check(gdb > gdr and gdg > gdr,
+  "Crystal heroine fishing pose receives denim-blue shorts")
+
+local missingGirlFish = {}
+local missingOk, missingErr = pcall(transform, {
+  exists = function(rel) return not rel:match("^fx/kris_fish_") end,
+  readImage = function(rel)
+    return rel:sub(1, 3) == "fx/" and sourceFishingPose() or sourceSheet()
+  end,
+  blank = function(w, h) return fakeImage(w, h) end,
+  writeImage = function(_, rel) missingGirlFish[rel] = true end,
+})
+T.check(missingOk,
+  "Gold/Silver run cleanly without Crystal fishing assets ("
+    .. tostring(missingErr) .. ")")
+T.eq(missingGirlFish["fx/kris_fish_down.png"], nil,
+  "missing Crystal fishing poses are skipped")
+
 run.release()
 T.finish("indigo_97")
-

--- a/mods/examples/indigo_97/tests/indigo_97_test.lua
+++ b/mods/examples/indigo_97/tests/indigo_97_test.lua
@@ -14,7 +14,7 @@ Data.sprites.SPRITE_KRIS = {
   id = "SPRITE_KRIS", image = "sprites/kris.png", frames = 6, walker = true,
 }
 Data.sprites.SPRITE_KRIS_BIKE = {
-  id = "SPRITE_KRIS_BIKE", image = "sprites/kris_bike.png", frames = 6,
+  id = "SPRITE_KRIS_BIKE", image = "sprites/krisbike.png", frames = 6,
 }
 
 local MOD = "mods/examples/indigo_97"
@@ -131,9 +131,11 @@ T.check(ok, "the transform runs in its restricted context (" .. tostring(err) ..
 T.check(written["sprites/chris.png"] ~= nil, "writes the walking sheet")
 T.check(written["sprites/chrisbike.png"] ~= nil, "writes the bicycle sheet")
 T.check(written["sprites/kris.png"] ~= nil, "writes the Crystal walking sheet")
-T.check(written["sprites/kris_bike.png"] ~= nil,
+T.check(written["sprites/krisbike.png"] ~= nil,
   "writes the Crystal bicycle sheet")
 for _, rel in ipairs({
+    "fx/gen2_fish_down.png", "fx/gen2_fish_up.png",
+    "fx/gen2_fish_side.png",
     "fx/chris_fish_down.png", "fx/chris_fish_up.png",
     "fx/chris_fish_side.png", "fx/kris_fish_down.png",
     "fx/kris_fish_up.png", "fx/kris_fish_side.png",
@@ -184,6 +186,12 @@ local fr, fg, fb = girl:getPixel(7, 5)
 T.check(fr > fg and fg > fb, "Crystal heroine receives warm skin")
 local yr, yg, yb = girl:getPixel(7, 10)
 T.check(yr > yg and yg > yb, "Crystal heroine receives a yellow top")
+local tearR, tearG, tearB = girl:getPixel(5, 7)
+T.check(not (tearR > tearG and tearR > tearB),
+  "front suspenders do not touch the heroine's face like red tears")
+local suspenderR, suspenderG, suspenderB = girl:getPixel(5, 9)
+T.check(suspenderR > suspenderG and suspenderR > suspenderB,
+  "front suspenders begin lower on the torso")
 local dr, dg, db = girl:getPixel(7, 13)
 T.check(db > dr and dg > dr, "Crystal heroine receives denim-blue shorts")
 local er, eg, eb = girl:getPixel(7, 14)
@@ -198,6 +206,10 @@ T.check(bfb > bfg and bfg > bfr,
 local bsr, bsg, bsb = boyFish:getPixel(6, 5)
 T.check(bsb > bsg and bsg > bsr,
   "boy fishing pose receives pale trouser shading")
+local goldFish = written["fx/gen2_fish_down.png"]
+local gfr, gfg, gfb = goldFish:getPixel(6, 3)
+T.check(gfb > gfg and gfg > gfr,
+  "Gold/Silver shared fishing pose receives the blue jacket treatment")
 local girlFish = written["fx/kris_fish_down.png"]
 local gyr, gyg, gyb = girlFish:getPixel(6, 3)
 T.check(gyr > gyg and gyg > gyb,
@@ -220,6 +232,56 @@ T.check(missingOk,
     .. tostring(missingErr) .. ")")
 T.eq(missingGirlFish["fx/kris_fish_down.png"], nil,
   "missing Crystal fishing poses are skipped")
+
+local goldOnly = {}
+local goldOk, goldErr = pcall(transform, {
+  exists = function(rel)
+    return rel == "sprites/chris.png"
+      or rel == "sprites/chrisbike.png"
+      or rel:match("^fx/gen2_fish_") ~= nil
+  end,
+  readImage = function(rel)
+    return rel:sub(1, 3) == "fx/" and sourceFishingPose() or sourceSheet()
+  end,
+  blank = function(w, h) return fakeImage(w, h) end,
+  writeImage = function(_, rel) goldOnly[rel] = true end,
+})
+T.check(goldOk,
+  "Gold's actual imported asset set transforms cleanly ("
+    .. tostring(goldErr) .. ")")
+for _, rel in ipairs({
+    "fx/gen2_fish_down.png", "fx/gen2_fish_up.png",
+    "fx/gen2_fish_side.png",
+  }) do
+  T.eq(goldOnly[rel], true, "Gold writes its imported pose " .. rel)
+end
+T.eq(goldOnly["fx/chris_fish_down.png"], nil,
+  "Gold does not require Crystal's per-character pose paths")
+
+local crystalOnly = {}
+local crystalOk, crystalErr = pcall(transform, {
+  exists = function(rel)
+    return rel == "sprites/chris.png"
+      or rel == "sprites/chrisbike.png"
+      or rel == "sprites/kris.png"
+      or rel == "sprites/krisbike.png"
+      or rel:match("^fx/chris_fish_") ~= nil
+      or rel:match("^fx/kris_fish_") ~= nil
+      or rel:match("^fx/gen2_fish_") ~= nil
+  end,
+  readImage = function(rel)
+    return rel:sub(1, 3) == "fx/" and sourceFishingPose() or sourceSheet()
+  end,
+  blank = function(w, h) return fakeImage(w, h) end,
+  writeImage = function(_, rel) crystalOnly[rel] = true end,
+})
+T.check(crystalOk,
+  "Crystal's actual imported asset set transforms cleanly ("
+    .. tostring(crystalErr) .. ")")
+T.eq(crystalOnly["sprites/krisbike.png"], true,
+  "Crystal writes the importer's real krisbike.png path")
+T.eq(crystalOnly["sprites/kris_bike.png"], nil,
+  "Crystal does not depend on the obsolete underscored bike path")
 
 run.release()
 T.finish("indigo_97")

--- a/mods/examples/indigo_97/tests/indigo_97_test.lua
+++ b/mods/examples/indigo_97/tests/indigo_97_test.lua
@@ -1,0 +1,122 @@
+-- Standalone from the Gen2Recomped repository root:
+--   luajit mods/examples/indigo_97/tests/indigo_97_test.lua
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.modkit")
+local Data = T.fixtures.fresh()
+Data.sprites.SPRITE_RED = {
+  id = "SPRITE_RED", image = "sprites/chris.png", frames = 6, walker = true,
+}
+Data.sprites.SPRITE_RED_BIKE = {
+  id = "SPRITE_RED_BIKE", image = "sprites/chrisbike.png", frames = 6,
+}
+
+local MOD = "mods/examples/indigo_97"
+
+local function noCacheFs()
+  local inner = T.fs.new(".")
+  local overlay = {}
+  local mount = "mods/indigo_97"
+
+  local function map(path)
+    if path == mount then return MOD end
+    if path and path:sub(1, #mount + 1) == mount .. "/" then
+      return MOD .. path:sub(#mount + 1)
+    end
+    return path
+  end
+
+  local fs = { root = inner.root }
+  function fs.read(path)
+    if path:sub(1, 17) == "assets/generated/" then return nil end
+    return overlay[path] or inner.read(map(path))
+  end
+  function fs.write(path, body) overlay[path] = body return true end
+  function fs.createDirectory() return true end
+  function fs.load(path) return inner.load(map(path)) end
+  function fs.getInfo(path)
+    if path == "mods" then return { type = "directory" } end
+    if path:sub(1, 17) == "assets/generated/" then return nil end
+    if overlay[path] then return { type = "file" } end
+    return inner.getInfo(map(path))
+  end
+  function fs.getDirectoryItems(path)
+    if path == "mods" then return { "indigo_97" } end
+    return inner.getDirectoryItems(map(path))
+  end
+  return fs
+end
+
+local run = T.sdk.loadMod("mods/indigo_97", { data = Data, fs = noCacheFs() })
+T.eq(#run.errors, 0,
+  "loads clean with no imported cache (" .. tostring(run.errors[1]) .. ")")
+T.eq(run.mod and run.mod.manifest.assets_transforms, "transforms.lua",
+  "declares the ROM-safe asset transform")
+
+for _, id in ipairs({ "SPRITE_RED", "SPRITE_RED_BIKE" }) do
+  local sprite = Data.sprites[id]
+  T.check(sprite ~= nil, id .. " remains registered")
+  T.eq(sprite.trueColor, true, id .. " opts out of the world shade remap")
+  T.check(sprite.image ~= nil and sprite.image ~= "", id .. " keeps its source path")
+end
+
+local function fakeImage(width, height, initial)
+  local data = {}
+  local image = {}
+  local function key(x, y) return y * width + x end
+  function image:getDimensions() return width, height end
+  function image:getPixel(x, y)
+    local p = data[key(x, y)] or initial or { 0, 0, 0, 0 }
+    return p[1], p[2], p[3], p[4]
+  end
+  function image:setPixel(x, y, r, g, b, a)
+    data[key(x, y)] = { r, g, b, a }
+  end
+  return image
+end
+
+local function sourceSheet()
+  local image = fakeImage(16, 96, { 1, 1, 1, 1 })
+  -- A simple opaque figure in every frame exercises transparency, region
+  -- colours and all six direction/step slots without carrying game artwork.
+  for frame = 0, 5 do
+    local fy = frame * 16
+    for y = 0, 15 do
+      for x = 5, 10 do
+        local shade = (x == 5 or x == 10 or y == 0 or y == 15) and 0 or 1 / 3
+        image:setPixel(x, fy + y, shade, shade, shade, 1)
+      end
+    end
+    image:setPixel(5, fy, 0, 0, 0, 1)
+    image:setPixel(7, fy + 7, 2 / 3, 2 / 3, 2 / 3, 1)
+  end
+  return image
+end
+
+local transform = assert(loadfile(MOD .. "/transforms.lua"))()
+T.check(type(transform) == "function", "transforms.lua returns function(ctx)")
+
+local written = {}
+local ok, err = pcall(transform, {
+  exists = function() return true end,
+  readImage = function() return sourceSheet() end,
+  blank = function(w, h) return fakeImage(w, h) end,
+  writeImage = function(image, rel) written[rel] = image end,
+})
+T.check(ok, "the transform runs in its restricted context (" .. tostring(err) .. ")")
+T.check(written["sprites/chris.png"] ~= nil, "writes the walking sheet")
+T.check(written["sprites/chrisbike.png"] ~= nil, "writes the bicycle sheet")
+
+local walk = written["sprites/chris.png"]
+local _, _, _, transparent = walk:getPixel(0, 0)
+T.eq(transparent, 0, "OBJ colour 0 becomes transparent")
+local rr, rg, rb, ra = walk:getPixel(6, 4)
+T.check(ra == 1 and rr > rg and rr > rb, "cap region becomes opaque red")
+local wr, wg, wb = walk:getPixel(7, 2)
+T.check(wr > 0.6 and wg > 0.6 and wb > 0.6, "cap front receives its pale panel")
+local sr, sg, sb = walk:getPixel(7, 7)
+T.check(sr > sg and sg > sb, "face region receives a warm skin tone")
+
+run.release()
+T.finish("indigo_97")
+

--- a/mods/examples/indigo_97/tests/indigo_97_test.lua
+++ b/mods/examples/indigo_97/tests/indigo_97_test.lua
@@ -10,6 +10,12 @@ Data.sprites.SPRITE_RED = {
 Data.sprites.SPRITE_RED_BIKE = {
   id = "SPRITE_RED_BIKE", image = "sprites/chrisbike.png", frames = 6,
 }
+Data.sprites.SPRITE_KRIS = {
+  id = "SPRITE_KRIS", image = "sprites/kris.png", frames = 6, walker = true,
+}
+Data.sprites.SPRITE_KRIS_BIKE = {
+  id = "SPRITE_KRIS_BIKE", image = "sprites/kris_bike.png", frames = 6,
+}
 
 local MOD = "mods/examples/indigo_97"
 
@@ -53,7 +59,9 @@ T.eq(#run.errors, 0,
 T.eq(run.mod and run.mod.manifest.assets_transforms, "transforms.lua",
   "declares the ROM-safe asset transform")
 
-for _, id in ipairs({ "SPRITE_RED", "SPRITE_RED_BIKE" }) do
+for _, id in ipairs({
+    "SPRITE_RED", "SPRITE_RED_BIKE", "SPRITE_KRIS", "SPRITE_KRIS_BIKE",
+  }) do
   local sprite = Data.sprites[id]
   T.check(sprite ~= nil, id .. " remains registered")
   T.eq(sprite.trueColor, true, id .. " opts out of the world shade remap")
@@ -106,6 +114,9 @@ local ok, err = pcall(transform, {
 T.check(ok, "the transform runs in its restricted context (" .. tostring(err) .. ")")
 T.check(written["sprites/chris.png"] ~= nil, "writes the walking sheet")
 T.check(written["sprites/chrisbike.png"] ~= nil, "writes the bicycle sheet")
+T.check(written["sprites/kris.png"] ~= nil, "writes the Crystal walking sheet")
+T.check(written["sprites/kris_bike.png"] ~= nil,
+  "writes the Crystal bicycle sheet")
 
 local walk = written["sprites/chris.png"]
 local _, _, _, transparent = walk:getPixel(0, 0)
@@ -116,6 +127,46 @@ local wr, wg, wb = walk:getPixel(7, 2)
 T.check(wr > 0.6 and wg > 0.6 and wb > 0.6, "cap front receives its pale panel")
 local sr, sg, sb = walk:getPixel(7, 7)
 T.check(sr > sg and sg > sb, "face region receives a warm skin tone")
+
+local function fingerprint(image)
+  local count, sum = 0, 0
+  for y = 0, 95 do
+    for x = 0, 15 do
+      local r, g, b, a = image:getPixel(x, y)
+      if a > 0 then
+        count = count + 1
+        local value = math.floor(r * 255 + 0.5) * 65536
+          + math.floor(g * 255 + 0.5) * 256
+          + math.floor(b * 255 + 0.5)
+        sum = (sum + value * (x + 1) * (y + 1)) % 9007199254740881
+      end
+    end
+  end
+  return count, sum
+end
+
+local walkCount, walkSum = fingerprint(written["sprites/chris.png"])
+local bikeCount, bikeSum = fingerprint(written["sprites/chrisbike.png"])
+T.eq(walkCount, 576, "boy walking transform keeps the 1.0.0 opaque mask")
+T.eq(walkSum, 1391291369803,
+  "boy walking transform is pixel-identical to 1.0.0")
+T.eq(bikeCount, 576, "boy bicycle transform keeps the 1.0.0 opaque mask")
+T.eq(bikeSum, 1498433350348,
+  "boy bicycle transform is pixel-identical to 1.0.0")
+
+local girl = written["sprites/kris.png"]
+local hr, hg, hb = girl:getPixel(7, 2)
+T.check(hr > hg and hg > hb, "Crystal heroine receives orange hair")
+local fr, fg, fb = girl:getPixel(7, 5)
+T.check(fr > fg and fg > fb, "Crystal heroine receives warm skin")
+local yr, yg, yb = girl:getPixel(7, 10)
+T.check(yr > yg and yg > yb, "Crystal heroine receives a yellow top")
+local dr, dg, db = girl:getPixel(7, 13)
+T.check(db > dr and dg > dr, "Crystal heroine receives denim-blue shorts")
+local er, eg, eb = girl:getPixel(7, 14)
+T.check(er > eg and er > eb, "Crystal heroine receives red shoes")
+local tr, tg, tb = girl:getPixel(7, 16 + 10)
+T.check(tg > tb and tb > tr, "Crystal heroine receives a teal backpack")
 
 run.release()
 T.finish("indigo_97")

--- a/mods/examples/indigo_97/transforms.lua
+++ b/mods/examples/indigo_97/transforms.lua
@@ -12,6 +12,15 @@ local SHEETS = {
   { path = "sprites/kris_bike.png", bike = true, style = "cerulean" },
 }
 
+local FISHING_POSES = {
+  { path = "fx/chris_fish_down.png", direction = "down", style = "indigo" },
+  { path = "fx/chris_fish_up.png", direction = "up", style = "indigo" },
+  { path = "fx/chris_fish_side.png", direction = "side", style = "indigo" },
+  { path = "fx/kris_fish_down.png", direction = "down", style = "cerulean" },
+  { path = "fx/kris_fish_up.png", direction = "up", style = "cerulean" },
+  { path = "fx/kris_fish_side.png", direction = "side", style = "cerulean" },
+}
+
 local C = {
   ink = { 20, 23, 31 },
   hair = { 38, 34, 42 },
@@ -77,6 +86,22 @@ local function sourceShade(source, x, y, frameY)
   if x < 0 or x >= 16 or y < frameY or y >= frameY + 16 then return 0 end
   local r, _, _, a = source:getPixel(x, y)
   return shadeIndex(r, a)
+end
+
+local function poseShade(source, x, y)
+  if x < 0 or x >= 16 or y < 0 or y >= 8 then return 0 end
+  local r, _, _, a = source:getPixel(x, y)
+  return shadeIndex(r, a)
+end
+
+-- The pose is only the lower eight pixels of the 16x16 standing frame. Its
+-- top edge meets the ordinary walking sheet, so absence above row zero is not
+-- an outline; all other exposed edges are.
+local function isPoseBoundary(source, x, y)
+  return poseShade(source, x - 1, y) == 0
+    or poseShade(source, x + 1, y) == 0
+    or (y > 0 and poseShade(source, x, y - 1) == 0)
+    or poseShade(source, x, y + 1) == 0
 end
 
 local function isBoundary(source, x, y, frameY)
@@ -296,6 +321,80 @@ local function colourGirlSheet(ctx, source, bike)
   return out
 end
 
+local function boyFishingColour(direction, x, localY, shade, boundary)
+  local colour
+
+  if localY <= 9 then
+    if direction == "up" then
+      colour = region(shade, boundary, C.hair_hi, C.hair, C.hair_dark)
+    else
+      colour = toned(shade, C.skin, C.skin_shadow)
+      if direction == "side" and x >= 9 then
+        colour = region(shade, boundary, C.hair_hi, C.hair, C.hair_dark)
+      end
+    end
+  else
+    if direction == "up" then
+      colour = region(shade, boundary, C.green_hi, C.green, C.green_dark)
+    else
+      colour = region(shade, boundary, C.blue_hi, C.blue, C.navy)
+    end
+    if localY <= 12 and (x <= 3 or x >= 12) then
+      colour = region(shade, boundary, C.green_hi, C.green, C.green_dark)
+    end
+    if localY >= 13 then
+      colour = region(shade, boundary, C.denim_hi, C.denim, C.denim_dark)
+    end
+    if localY >= 14 then
+      colour = region(shade, boundary, C.white, C.red, C.red_dark)
+    end
+  end
+
+  if direction == "down" and (localY == 10 or localY == 11)
+      and x >= 7 and x <= 8 then
+    colour = shade == 3 and C.ink or C.navy
+  end
+
+  return colour
+end
+
+local function girlFishingColour(direction, x, localY, shade, boundary)
+  local headEnd = direction == "side" and 9 or 6
+  if localY <= headEnd then
+    return girlHeadColour(direction, x, localY, shade, boundary)
+  end
+  if localY >= 14 then
+    return accent(shade, C.red_hi, C.red, C.red_dark)
+  end
+  if localY >= 12 then
+    return region(shade, boundary, C.denim_hi, C.denim, C.denim_dark)
+  end
+  return girlBodyColour(direction, x, localY, shade, boundary)
+end
+
+local function colourFishingPose(ctx, source, style, direction)
+  local width, height = source:getDimensions()
+  if width ~= 16 or height ~= 8 then return nil end
+  local out = ctx.blank(width, height)
+
+  for y = 0, 7 do
+    local localY = y + 8
+    for x = 0, 15 do
+      local r, _, _, a = source:getPixel(x, y)
+      local shade = shadeIndex(r, a)
+      if shade ~= 0 then
+        local boundary = isPoseBoundary(source, x, y)
+        local colour = style == "cerulean"
+          and girlFishingColour(direction, x, localY, shade, boundary)
+          or boyFishingColour(direction, x, localY, shade, boundary)
+        put(out, x, y, colour)
+      end
+    end
+  end
+
+  return out
+end
+
 return function(ctx)
   for _, sheet in ipairs(SHEETS) do
     if ctx.exists(sheet.path) then
@@ -305,5 +404,12 @@ return function(ctx)
       if result then ctx.writeImage(result, sheet.path) end
     end
   end
-end
 
+  for _, pose in ipairs(FISHING_POSES) do
+    if ctx.exists(pose.path) then
+      local result = colourFishingPose(ctx, ctx.readImage(pose.path),
+        pose.style, pose.direction)
+      if result then ctx.writeImage(result, pose.path) end
+    end
+  end
+end

--- a/mods/examples/indigo_97/transforms.lua
+++ b/mods/examples/indigo_97/transforms.lua
@@ -9,10 +9,16 @@ local SHEETS = {
   { path = "sprites/chris.png", bike = false, style = "indigo" },
   { path = "sprites/chrisbike.png", bike = true, style = "indigo" },
   { path = "sprites/kris.png", bike = false, style = "cerulean" },
-  { path = "sprites/kris_bike.png", bike = true, style = "cerulean" },
+  { path = "sprites/krisbike.png", bike = true, style = "cerulean" },
 }
 
 local FISHING_POSES = {
+  -- Gold and Silver expose the shared Chris strips through the original
+  -- field-effect paths. Crystal additionally exposes the per-character paths
+  -- below so its boy/girl selection can swap fishing art with the player form.
+  { path = "fx/gen2_fish_down.png", direction = "down", style = "indigo" },
+  { path = "fx/gen2_fish_up.png", direction = "up", style = "indigo" },
+  { path = "fx/gen2_fish_side.png", direction = "side", style = "indigo" },
   { path = "fx/chris_fish_down.png", direction = "down", style = "indigo" },
   { path = "fx/chris_fish_up.png", direction = "up", style = "indigo" },
   { path = "fx/chris_fish_side.png", direction = "side", style = "indigo" },
@@ -262,7 +268,10 @@ local function girlBodyColour(direction, x, localY, shade, boundary)
   if localY <= 9 and (x <= 3 or x >= 12) then
     return toned(shade, C.skin, C.skin_shadow)
   end
-  if (x == 5 or x == 10) and localY <= 12 then
+  -- The red suspenders start on the torso.  Beginning them at localY 7 put
+  -- two red pixels directly against the bottom of Kris's face, which read as
+  -- tears in the enlarged voxel view.
+  if (x == 5 or x == 10) and localY >= 9 and localY <= 12 then
     return accent(shade, C.red_hi, C.red, C.red_dark)
   end
   return region(shade, boundary, C.yellow_hi, C.yellow, C.yellow_dark)

--- a/mods/examples/indigo_97/transforms.lua
+++ b/mods/examples/indigo_97/transforms.lua
@@ -1,0 +1,186 @@
+-- INDIGO//97 asset transform
+--
+-- Runs once inside Gen2Recomped's restricted transform sandbox. It reads the
+-- boy player's sheets from the player's private ROM cache and writes only the
+-- recoloured result to save/mod-derived/indigo_97. No cartridge pixels ship in
+-- this repository or its release ZIP.
+
+local SHEETS = {
+  { path = "sprites/chris.png", bike = false },
+  { path = "sprites/chrisbike.png", bike = true },
+}
+
+local C = {
+  ink = { 20, 23, 31 },
+  hair = { 38, 34, 42 },
+  hair_hi = { 78, 65, 68 },
+  hair_dark = { 25, 24, 31 },
+  red = { 211, 43, 47 },
+  red_hi = { 246, 78, 65 },
+  red_dark = { 131, 30, 39 },
+  white = { 246, 239, 213 },
+  white_shadow = { 191, 198, 194 },
+  white_dark = { 125, 132, 132 },
+  skin = { 232, 164, 101 },
+  skin_shadow = { 181, 101, 64 },
+  blue = { 38, 105, 177 },
+  blue_hi = { 71, 143, 211 },
+  navy = { 24, 53, 102 },
+  denim = { 118, 172, 202 },
+  denim_hi = { 165, 207, 222 },
+  denim_dark = { 61, 105, 137 },
+  green = { 52, 132, 65 },
+  green_hi = { 88, 171, 83 },
+  green_dark = { 28, 79, 45 },
+  steel = { 105, 119, 128 },
+  steel_hi = { 180, 190, 188 },
+}
+
+local DIRECTIONS = { "down", "up", "side", "down", "up", "side" }
+
+local function shadeIndex(r, a)
+  if a == 0 or r > 0.83 then return 0 end -- OBJ colour 0 is transparent
+  if r > 0.5 then return 1 end
+  if r > 0.17 then return 2 end
+  return 3
+end
+
+local function put(image, x, y, colour)
+  image:setPixel(x, y,
+    colour[1] / 255, colour[2] / 255, colour[3] / 255, 1)
+end
+
+local function toned(shade, highlight, base)
+  if shade == 3 then return C.ink end
+  return shade == 1 and highlight or base
+end
+
+local function region(shade, boundary, highlight, base, shadow)
+  if boundary then return C.ink end
+  if shade == 1 then return highlight end
+  if shade == 2 then return base end
+  return shadow
+end
+
+local function sourceShade(source, x, y, frameY)
+  if x < 0 or x >= 16 or y < frameY or y >= frameY + 16 then return 0 end
+  local r, _, _, a = source:getPixel(x, y)
+  return shadeIndex(r, a)
+end
+
+local function isBoundary(source, x, y, frameY)
+  return sourceShade(source, x - 1, y, frameY) == 0
+    or sourceShade(source, x + 1, y, frameY) == 0
+    or sourceShade(source, x, y - 1, frameY) == 0
+    or sourceShade(source, x, y + 1, frameY) == 0
+end
+
+local function capColour(direction, x, localY, shade, boundary)
+  local whitePanel = (direction == "down" and x >= 6 and x <= 9
+      and localY >= 1 and localY <= 3)
+    or (direction == "side" and x >= 8 and x <= 12
+      and localY >= 2 and localY <= 4)
+
+  if whitePanel then
+    if not boundary and shade == 3 and x >= 7 and x <= 9 then
+      return C.green_dark
+    end
+    return region(shade, boundary, C.white, C.white_shadow, C.white_dark)
+  end
+  return region(shade, boundary, C.red_hi, C.red, C.red_dark)
+end
+
+local function colourSheet(ctx, source, bike)
+  local width, height = source:getDimensions()
+  if width ~= 16 or height < 96 then return nil end
+  local out = ctx.blank(width, height)
+
+  for y = 0, 95 do
+    local frame = math.floor(y / 16)
+    local frameY = frame * 16
+    local top = (not bike and frame >= 3) and 1 or 0
+    local direction = DIRECTIONS[frame + 1]
+    local localY = (y - frameY) - top
+
+    for x = 0, 15 do
+      local r, _, _, a = source:getPixel(x, y)
+      local shade = shadeIndex(r, a)
+      if shade ~= 0 then
+        local boundary = isBoundary(source, x, y, frameY)
+        local colour
+
+        if localY <= 4 then
+          colour = capColour(direction, x, localY, shade, boundary)
+        elseif localY <= 9 then
+          if direction == "up" then
+            colour = region(shade, boundary, C.hair_hi, C.hair, C.hair_dark)
+          else
+            colour = toned(shade, C.skin, C.skin_shadow)
+            if direction == "side" and x >= 9 then
+              colour = region(shade, boundary, C.hair_hi, C.hair, C.hair_dark)
+            end
+          end
+        else
+          colour = C.ink
+        end
+
+        if bike and localY >= 10 then
+          if direction == "up" then
+            colour = region(shade, boundary, C.green_hi, C.green, C.green_dark)
+          else
+            colour = region(shade, boundary, C.blue_hi, C.blue, C.navy)
+          end
+          if localY <= 11 and (x <= 3 or x >= 12) then
+            colour = region(shade, boundary, C.green_hi, C.green, C.green_dark)
+          end
+          if localY >= 12 then
+            local sideWheel = direction == "side" and (x <= 4 or x >= 11)
+            if shade == 3 then
+              colour = C.ink
+            elseif sideWheel then
+              colour = shade == 1 and C.steel_hi or C.steel
+            elseif shade == 1 then
+              colour = C.steel_hi
+            else
+              colour = C.red
+            end
+          end
+        elseif not bike and localY >= 10 then
+          if direction == "up" then
+            colour = region(shade, boundary, C.green_hi, C.green, C.green_dark)
+          else
+            colour = region(shade, boundary, C.blue_hi, C.blue, C.navy)
+          end
+          if localY <= 12 and (x <= 3 or x >= 12) then
+            colour = region(shade, boundary, C.green_hi, C.green, C.green_dark)
+          end
+          if y - frameY >= 13 then
+            colour = region(shade, boundary, C.denim_hi, C.denim, C.denim_dark)
+          end
+          if y - frameY >= 14 then
+            colour = region(shade, boundary, C.white, C.red, C.red_dark)
+          end
+        end
+
+        if direction == "down" and not bike
+            and (localY == 10 or localY == 11) and x >= 7 and x <= 8 then
+          colour = shade == 3 and C.ink or C.navy
+        end
+
+        put(out, x, y, colour)
+      end
+    end
+  end
+
+  return out
+end
+
+return function(ctx)
+  for _, sheet in ipairs(SHEETS) do
+    if ctx.exists(sheet.path) then
+      local result = colourSheet(ctx, ctx.readImage(sheet.path), sheet.bike)
+      if result then ctx.writeImage(result, sheet.path) end
+    end
+  end
+end
+

--- a/mods/examples/indigo_97/transforms.lua
+++ b/mods/examples/indigo_97/transforms.lua
@@ -1,13 +1,15 @@
 -- INDIGO//97 asset transform
 --
 -- Runs once inside Gen2Recomped's restricted transform sandbox. It reads the
--- boy player's sheets from the player's private ROM cache and writes only the
+-- player sheets from the player's private ROM cache and writes only the
 -- recoloured result to save/mod-derived/indigo_97. No cartridge pixels ship in
 -- this repository or its release ZIP.
 
 local SHEETS = {
-  { path = "sprites/chris.png", bike = false },
-  { path = "sprites/chrisbike.png", bike = true },
+  { path = "sprites/chris.png", bike = false, style = "indigo" },
+  { path = "sprites/chrisbike.png", bike = true, style = "indigo" },
+  { path = "sprites/kris.png", bike = false, style = "cerulean" },
+  { path = "sprites/kris_bike.png", bike = true, style = "cerulean" },
 }
 
 local C = {
@@ -15,6 +17,9 @@ local C = {
   hair = { 38, 34, 42 },
   hair_hi = { 78, 65, 68 },
   hair_dark = { 25, 24, 31 },
+  auburn = { 126, 51, 31 },
+  orange = { 230, 96, 35 },
+  orange_hi = { 255, 151, 55 },
   red = { 211, 43, 47 },
   red_hi = { 246, 78, 65 },
   red_dark = { 131, 30, 39 },
@@ -29,6 +34,12 @@ local C = {
   denim = { 118, 172, 202 },
   denim_hi = { 165, 207, 222 },
   denim_dark = { 61, 105, 137 },
+  yellow = { 239, 185, 40 },
+  yellow_hi = { 255, 224, 92 },
+  yellow_dark = { 157, 105, 27 },
+  teal = { 34, 139, 129 },
+  teal_hi = { 77, 184, 168 },
+  teal_dark = { 18, 76, 75 },
   green = { 52, 132, 65 },
   green_hi = { 88, 171, 83 },
   green_dark = { 28, 79, 45 },
@@ -90,7 +101,9 @@ local function capColour(direction, x, localY, shade, boundary)
   return region(shade, boundary, C.red_hi, C.red, C.red_dark)
 end
 
-local function colourSheet(ctx, source, bike)
+-- This is the 1.0.0 boy transform. Keep its logic unchanged: existing users
+-- must get exactly the same generated pixels after upgrading.
+local function colourBoySheet(ctx, source, bike)
   local width, height = source:getDimensions()
   if width ~= 16 or height < 96 then return nil end
   local out = ctx.blank(width, height)
@@ -175,10 +188,120 @@ local function colourSheet(ctx, source, bike)
   return out
 end
 
+local function accent(shade, highlight, base, dark)
+  if shade == 1 then return highlight end
+  if shade == 2 then return base end
+  return dark
+end
+
+local function girlHairColour(shade, boundary)
+  if boundary or shade == 3 then return C.auburn end
+  return shade == 1 and C.orange_hi or C.orange
+end
+
+local function girlHeadColour(direction, x, localY, shade, boundary)
+  if direction == "up" then
+    return girlHairColour(shade, boundary)
+  end
+
+  local face = direction == "down"
+      and localY >= 3 and localY <= 6 and x >= 5 and x <= 10
+    or direction == "side"
+      and localY >= 3 and localY <= 8 and x >= 5 and x <= 8
+
+  if face then return toned(shade, C.skin, C.skin_shadow) end
+  return girlHairColour(shade, boundary)
+end
+
+local function girlBodyColour(direction, x, localY, shade, boundary)
+  if direction == "up" then
+    if localY <= 9 and (x <= 3 or x >= 12) then
+      return toned(shade, C.skin, C.skin_shadow)
+    end
+    return region(shade, boundary, C.teal_hi, C.teal, C.teal_dark)
+  end
+
+  if direction == "side" then
+    if localY <= 10 and x <= 5 then
+      return toned(shade, C.skin, C.skin_shadow)
+    end
+    if x >= 10 then
+      return region(shade, boundary, C.teal_hi, C.teal, C.teal_dark)
+    end
+    if x == 7 then
+      return accent(shade, C.red_hi, C.red, C.red_dark)
+    end
+    return region(shade, boundary, C.yellow_hi, C.yellow, C.yellow_dark)
+  end
+
+  if localY <= 9 and (x <= 3 or x >= 12) then
+    return toned(shade, C.skin, C.skin_shadow)
+  end
+  if (x == 5 or x == 10) and localY <= 12 then
+    return accent(shade, C.red_hi, C.red, C.red_dark)
+  end
+  return region(shade, boundary, C.yellow_hi, C.yellow, C.yellow_dark)
+end
+
+local function girlBikeColour(direction, x, localY, shade, boundary)
+  if localY <= 11 then
+    return girlBodyColour(direction, x, localY, shade, boundary)
+  end
+
+  local sideWheel = direction == "side" and (x <= 4 or x >= 11)
+  if shade == 3 then return C.ink end
+  if sideWheel then return shade == 1 and C.steel_hi or C.steel end
+  if shade == 1 then return C.steel_hi end
+  return C.red
+end
+
+local function colourGirlSheet(ctx, source, bike)
+  local width, height = source:getDimensions()
+  if width ~= 16 or height < 96 then return nil end
+  local out = ctx.blank(width, height)
+
+  for y = 0, 95 do
+    local frame = math.floor(y / 16)
+    local frameY = frame * 16
+    local top = (not bike and frame >= 3) and 1 or 0
+    local direction = DIRECTIONS[frame + 1]
+    local localY = (y - frameY) - top
+    local headEnd = direction == "side" and 9 or 6
+
+    for x = 0, 15 do
+      local r, _, _, a = source:getPixel(x, y)
+      local shade = shadeIndex(r, a)
+      if shade ~= 0 then
+        local boundary = isBoundary(source, x, y, frameY)
+        local colour
+
+        if localY <= headEnd then
+          colour = girlHeadColour(direction, x, localY, shade, boundary)
+        elseif bike then
+          colour = girlBikeColour(direction, x, localY, shade, boundary)
+        elseif localY >= 14 then
+          colour = accent(shade, C.red_hi, C.red, C.red_dark)
+        elseif localY >= 12 then
+          colour = region(shade, boundary,
+            C.denim_hi, C.denim, C.denim_dark)
+        else
+          colour = girlBodyColour(direction, x, localY, shade, boundary)
+        end
+
+        put(out, x, y, colour)
+      end
+    end
+  end
+
+  return out
+end
+
 return function(ctx)
   for _, sheet in ipairs(SHEETS) do
     if ctx.exists(sheet.path) then
-      local result = colourSheet(ctx, ctx.readImage(sheet.path), sheet.bike)
+      local colour = sheet.style == "cerulean"
+        and colourGirlSheet or colourBoySheet
+      local result = colour(ctx, ctx.readImage(sheet.path), sheet.bike)
       if result then ctx.writeImage(result, sheet.path) end
     end
   end

--- a/tests/mod_examples_tests.lua
+++ b/tests/mod_examples_tests.lua
@@ -2,7 +2,7 @@
 -- entry loads clean through the real loader, produces its stated effect,
 -- and carries the metadata the polish checklist requires.
 --
--- The eight entries load TOGETHER against one dataset, which is the case a
+-- The nine entries load TOGETHER against one dataset, which is the case a
 -- player who enables the whole gallery gets and the only way to catch two
 -- examples fighting over the same id.
 package.path = "./?.lua;./?/init.lua;" .. package.path
@@ -22,6 +22,7 @@ local IDS = {
   "example_balance_tweaks", "example_shiny_palette", "example_jukebox",
   "example_lost_parcel", "example_weather", "example_dexnav",
   "example_mini_conversion", "example_silly_oak",
+  "indigo_97",
 }
 
 -- the closed vocabulary from 25 3.1; GAMEPLAY is the accepted v1 alias
@@ -356,3 +357,4 @@ Runtime.events, Runtime.hooks, Runtime.errors =
 Runtime.currentMod = nil
 
 S.finish()
+


### PR DESCRIPTION
## Summary

- add **INDIGO//97**, a late-1990s anime-inspired true-colour treatment for the Gen 2 boy player
- recolour walking and bicycle sheets through `transforms.lua` using the player's private imported cache
- preserve animation, movement, collision, saves and source sprite metadata
- add gallery documentation, metadata, changelog and a behavioral test suite
- register the ninth entry in the gallery coexistence test

## Validation

- `python3 tools/modkit.py validate mods/examples/indigo_97 --base fixture` — pass
- `python3 tools/modkit.py lint mods/examples/indigo_97` — pass; no ROM-derived content
- `luajit mods/examples/indigo_97/tests/indigo_97_test.lua` — 16/16 checks passed
- public v1.0.0 package installed and field-tested successfully on Steam Deck
- transform output matched the approved private walking and bicycle reference across all 3,072 tested pixels

## Legal and distribution posture

The PR contains no ROM, extracted sprite sheet or ROM-derived preview. The transform reads `sprites/chris.png` and `sprites/chrisbike.png` from the player's own imported cache and writes derived copies under `save/mod-derived/indigo_97`.

Public release and source: https://github.com/n47h4ni3l/gen2recomp-indigo97

## Compatibility

- Gen2Recomped `>=0.7.6 <1.0.0`
- Mod API 2
- Voxel Characters is an optional visual pairing
- Crystal girl, fishing poses, trainer-card portrait and battle portrait are intentionally unchanged in v1.0.0
