### PR TITLE
Implement timer for warp activation on carpet tiles

### DIFF
--- a/src/world/Warp.lua
+++ b/src/world/Warp.lua
@@ -53,18 +53,37 @@ local Warp = {}
 -- the call sites: the step handler was already filtering carpets out of the
 -- copy it uses to outrank coord events, and the copy it actually warps on --
 -- a second Warp.onArrive a hundred lines further down -- was not.
+-- Adding timer when walking out of buildings for free move mods. 0.5 seconds pushing foward on a door carpet tile will trigger warp, standing still wont trigger warp.
+
 function Warp.onArrive(map, cx, cy)
   local w = map:warpAtCell(cx, cy)
   if not (w and map:isWarpTileCell(cx, cy)) then return nil end
+  
   local Map = require("src.world.Map")
   local GameVersion = require("src.core.GameVersion")
-  -- Only where the cell answers in collision CLASSES. On a tile-id map those
-  -- four numbers mean nothing, and reading them as carpets would silently
-  -- disable real doors -- see Map:speaksGen2Collision.
+  
   if GameVersion.isGen2() and map.speaksGen2Collision and map:speaksGen2Collision()
      and Map.gen2IsDirectionalCarpet(map:cellTile(cx, cy)) then
+     
+    local Game = require("src.core.Game")
+    if Game and Game.input then
+      local holdingDir = Game.input:isDown("up") or Game.input:isDown("down") or 
+                         Game.input:isDown("left") or Game.input:isDown("right")
+                         
+      local now = love.timer.getTime()      
+      if holdingDir then
+        if not map.carpetHoldStartTime then
+          map.carpetHoldStartTime = now
+        elseif now - map.carpetHoldStartTime >= 0.5 then
+          map.carpetHoldStartTime = nil
+          return w 
+        end
+      else
+        map.carpetHoldStartTime = nil
+      end
+    end    
     return nil
-  end
+  end  
   return w
 end
 


### PR DESCRIPTION
Add a timer for triggering warp when walking on carpet tiles, allowing warp after holding a direction for 0.5 seconds on free move movement.