### PR TITLE
Restore Gen II summary previous/next navigation

### DIFF
--- a/src/ui/BoxMenu.lua
+++ b/src/ui/BoxMenu.lua
@@ -23,17 +23,34 @@ local function monName(game, mon)
   return mon.nickname or def.name
 end
 
+-- Keep a Bill's PC ListMenu cursor visible when SummaryMenu UP/DOWN changes
+-- the selected Pokemon while the list itself is underneath the status screen.
+local function setListIndex(list, index)
+  list.index = index
+  local rows = list.rows or 7
+  local scroll = list.scroll or 0
+  if index - scroll > rows then scroll = index - rows end
+  if index - scroll < 1 then scroll = index - 1 end
+  list.scroll = math.max(0, scroll)
+end
+
 -- Per-mon submenu (bills_pc.asm DisplayDepositWithdrawMenu): the chosen
 -- action + STATS + CANCEL.  STATS shows the status screen and returns
 -- here; CANCEL/B goes back to the list.
-local function monSubmenu(game, action, mon, onAction)
+local function monSubmenu(game, action, mons, list, onAction)
   game.stack:push(Menu.new(game, {
     { label = action, onSelect = onAction },
     {
       label = Strings("STATS"),
       keepOpen = true,
       onSelect = function()
-        require("src.ui.Screens").push(game, "SummaryMenu", mon)
+        local mon = mons[list.index]
+        if not mon then return end
+        require("src.ui.Screens").push(game, "SummaryMenu", mon, {
+          mons = mons,
+          index = list.index,
+          onMonChange = function(index) setListIndex(list, index) end,
+        })
       end,
     },
     { label = Strings("CANCEL") },
@@ -70,7 +87,11 @@ local function withdraw(game)
     onChoose = function(item, list)
       local mon = box[item.value]
       if not mon then return end
-      monSubmenu(game, "WITHDRAW", mon, function()
+      setListIndex(list, item.value)
+      monSubmenu(game, "WITHDRAW", box, list, function()
+        local index = list.index
+        local mon = box[index]
+        if not mon then return end
         if #game.save.party >= Party.MAX then
           list.footer = "The party is full!"
           return
@@ -83,7 +104,7 @@ local function withdraw(game)
         -- nil-indexes it (#304, same family as #233).  Already-shaped mons
         -- (everything the engine itself put in a box) pass through.
         Stats.ensure(game.data.pokemon[mon.species], mon)
-        table.remove(box, item.value)
+        table.remove(box, index)
         table.insert(game.save.party, mon)
         local name = monName(game, mon)
         game.stringBuffer = name
@@ -117,7 +138,11 @@ local function deposit(game)
     onChoose = function(item, list)
       local mon = game.save.party[item.value]
       if not mon then return end
-      monSubmenu(game, "DEPOSIT", mon, function()
+      setListIndex(list, item.value)
+      monSubmenu(game, "DEPOSIT", game.save.party, list, function()
+        local index = list.index
+        local mon = game.save.party[index]
+        if not mon then return end
         if #game.save.party <= 1 then
           list.footer = Strings("You need at least\none POKéMON!")
           return
@@ -127,7 +152,7 @@ local function deposit(game)
           list.footer = Strings("BOX %d is full!", game.save.currentBox)
           return
         end
-        table.remove(game.save.party, item.value)
+        table.remove(game.save.party, index)
         table.insert(active, mon)
         -- PIKAHAPPY_DEPOSITED (engine/pokemon/bills_pc.asm:247)
         require("src.world.PikachuFollower")

--- a/src/ui/PartyMenu.lua
+++ b/src/ui/PartyMenu.lua
@@ -516,7 +516,11 @@ function PartyMenu:update(dt)
       elseif action == "stats" then
         -- battle and field alike return to the party list afterwards
         -- (core.asm .partyMenuWasSelected)
-        Screens.push(self.game, "SummaryMenu", mon)
+        Screens.push(self.game, "SummaryMenu", mon, {
+          mons = party,
+          index = self.index,
+          onMonChange = function(index) self.index = index end,
+        })
       elseif action == "battle_switch" then
         self.game.stack:pop()
         self.onSwitch(mon)

--- a/src/ui/SummaryMenu.lua
+++ b/src/ui/SummaryMenu.lua
@@ -115,7 +115,8 @@ function SummaryMenu:sgbPalettes(game)
   return out
 end
 
-function SummaryMenu.new(game, mon)
+function SummaryMenu.new(game, mon, opts)
+  opts = opts or {}
   -- status_screen.asm:66-76: StatusScreen recalculates the stat block before
   -- it draws anything when the mon came from a box or the daycare ("mon is
   -- in a box or daycare" -> CalcStats), because box_struct carries none.
@@ -126,7 +127,14 @@ function SummaryMenu.new(game, mon)
   -- SaveData.validate has run over a loaded save, but this is the site the
   -- original recomputes at, and it also covers a mon handed in by a mod.
   Stats.ensure(game.data.pokemon[mon.species], mon)
-  local self = setmetatable({ game = game, mon = mon, page = 1 }, SummaryMenu)
+  local self = setmetatable({
+    game = game,
+    mon = mon,
+    page = 1,
+    mons = opts.mons,
+    monIndex = opts.index,
+    onMonChange = opts.onMonChange,
+  }, SummaryMenu)
   self.isEgg = require("src.pokemon.Party").isEgg(mon) and true or false
   local Sprites = require("src.pokemon.Sprites")
   if self.isEgg then
@@ -158,11 +166,52 @@ function SummaryMenu.new(game, mon)
   return self
 end
 
+local function sourceIndex(self)
+  local mons = self.mons
+  if type(mons) ~= "table" then return nil end
+  local index = self.monIndex
+  if index and rawequal(mons[index], self.mon) then return index end
+  for i, mon in ipairs(mons) do
+    if rawequal(mon, self.mon) then return i end
+  end
+  return nil
+end
+
+-- Gen II StatsScreen_JoypadAction: UP/DOWN select the previous/next mon
+-- from the list that opened the status screen.  The current page is kept.
+function SummaryMenu:moveMon(delta)
+  local index = sourceIndex(self)
+  if not index then return false end
+  local nextIndex = index + delta
+  if nextIndex < 1 or nextIndex > #self.mons then return false end
+
+  local page, screenId = self.page, self.screenId
+  local fresh = SummaryMenu.new(self.game, self.mons[nextIndex], {
+    mons = self.mons,
+    index = nextIndex,
+    onMonChange = self.onMonChange,
+  })
+  fresh.page = page
+  fresh.screenId = screenId
+
+  for key in pairs(self) do self[key] = nil end
+  for key, value in pairs(fresh) do self[key] = value end
+
+  if self.onMonChange then self.onMonChange(nextIndex, self.mon) end
+  return true
+end
+
 function SummaryMenu:update(dt)
   local input = self.game.input
   if self.picAnim then self.picAnim:update(dt) end
   if self.isEgg then
-    if input:wasPressed("a") or input:wasPressed("b") then self.game.stack:pop() end
+    if input:wasPressed("a") or input:wasPressed("b") then
+      self.game.stack:pop()
+    elseif isGen2() and input:wasPressed("up") then
+      self:moveMon(-1)
+    elseif isGen2() and input:wasPressed("down") then
+      self:moveMon(1)
+    end
     return
   end
   if isGen2() then
@@ -174,6 +223,10 @@ function SummaryMenu:update(dt)
       self.page = self.page % 3 + 1
     elseif input:wasPressed("left") then
       self.page = (self.page + 1) % 3 + 1
+    elseif input:wasPressed("up") then
+      self:moveMon(-1)
+    elseif input:wasPressed("down") then
+      self:moveMon(1)
     end
     return
   end


### PR DESCRIPTION
Restores Gen II-style UP/DOWN Pokémon navigation in the summary screen.

Changes:
- UP/DOWN browses the previous/next Pokémon without closing the summary
- Preserves the current INFO / SKILLS / MOVES page
- Keeps the Party cursor synchronized
- Supports Bill's PC DEPOSIT and WITHDRAW lists
- Keeps PC list index and scroll synchronized, including full 20-Pokémon boxes
- Prevents wraparound at the first/last Pokémon

Testing:
- LuaJIT syntax checks passed for SummaryMenu.lua, PartyMenu.lua and BoxMenu.lua
- Tested locally on Gen2Recomp v0.7.35 with Pokémon Crystal (Rev A)
- Party navigation: PASS
- Page preservation: PASS
- First/last boundary behavior: PASS
- Party cursor synchronization: PASS
- Bill's PC DEPOSIT/WITHDRAW: PASS
- Full 20-Pokémon box scrolling: PASS