### PR TITLE
Implement Gen II held item battle runtime

### DIFF
--- a/src/battle/BattleState.lua
+++ b/src/battle/BattleState.lua
@@ -15,6 +15,7 @@ local Catching = require("src.battle.Catching")
 local Damage = require("src.battle.Damage")
 local EffectRegistry = require("src.battle.EffectRegistry")
 local Experience = require("src.battle.Experience")
+local HeldItems = require("src.battle.HeldItems")
 local Font = require("src.render.Font")
 local Logger = require("src.core.Logger")
 local MoveEffects = require("src.battle.MoveEffects")
@@ -2056,6 +2057,7 @@ function BattleState:enter()
   local function queueEnemyCry()
     self:act(function()
       require("src.core.Sound").playCry(self.data, self.enemy.mon.species)
+      HeldItems.onEntry(self, self.enemy)
     end)
   end
   -- PrintBeginningBattleText (engine/battle/common_text.asm:10-19): a wild
@@ -2176,6 +2178,7 @@ function BattleState:enter()
       -- out of the ball (AnimateSendingOutMon at hlcoord 4,11)
       self:startGrowIn(self.player)
       require("src.core.Sound").playCry(self.data, self.player.mon.species)
+      HeldItems.onEntry(self, self.player)
     end)
     self:markParticipant()
   end
@@ -2884,18 +2887,24 @@ function BattleState:accuracyRoll(move, user, target, accuracyRaw)
   if Runtime.wantsHook("battle.accuracy") then
     return Runtime.call("battle.accuracy", function(c)
       return Damage.accuracyRoll(c.ruleset, c.move, c.user, c.target, c.rng,
-                                 c.accuracyRaw)
+                                 c.accuracyRaw, c.data)
     end, { battle = self, ruleset = self.ruleset, move = move,
-           user = user, target = target, rng = self.rng,
+           user = user, target = target, rng = self.rng, data = self.data,
            accuracyRaw = accuracyRaw })
   end
   return Damage.accuracyRoll(self.ruleset, move, user, target, self.rng,
-                             accuracyRaw)
+                             accuracyRaw, self.data)
 end
 
 -- Damage.compute, hooked as battle.damage; the ctx table is only built
 -- when a chain is installed, so the no-mod path allocates nothing
 function BattleState:computeDamage(user, target, move, opts)
+  -- Damage's Gen II held-item path needs the imported item records alongside
+  -- the ordinary formula options. Keep Gen I's no-mod fast path allocation-free.
+  if self.data and self.data.constants and self.data.constants.generation == 2 then
+    opts = opts or {}
+    opts.data = opts.data or self.data
+  end
   -- DoWeatherModifiers reads wBattleWeather inside the damage calc; the port
   -- keeps it on the field, so it rides in on opts rather than widening
   -- Damage.compute's signature.  nil on Gen 1 and whenever no weather is up.
@@ -2941,6 +2950,7 @@ function BattleState:markParticipant()
   self.participants = self.participants or {}
   if self.player and self.player.mon then
     self.participants[self.player.mon] = true
+    HeldItems.observeParticipant(self, self.player)
   end
 end
 
@@ -2988,10 +2998,10 @@ function BattleState:resolveTurn(playerAction)
   local pFirst
   if Runtime.wantsHook("battle.turn_order") then
     pFirst = Runtime.call("battle.turn_order", function(a, aMove, b, bMove, c)
-      return TurnOrder.firstMover(a, aMove, b, bMove, c.rng, c.invertTie)
-    end, self.player, pMove, self.enemy, eMove, { rng = self.rng })
+      return TurnOrder.firstMover(a, aMove, b, bMove, c.rng, c.invertTie, c.data)
+    end, self.player, pMove, self.enemy, eMove, { rng = self.rng, data = self.data })
   else
-    pFirst = TurnOrder.firstMover(self.player, pMove, self.enemy, eMove, self.rng)
+    pFirst = TurnOrder.firstMover(self.player, pMove, self.enemy, eMove, self.rng, nil, self.data)
   end
   local order
   if pFirst then
@@ -3039,6 +3049,7 @@ function BattleState:resolveSwitch(newMon)
       -- SendOutMon (core.asm:1757-1762): poof, then the grow-in
       self:startGrowIn(self.player)
       require("src.core.Sound").playCry(self.data, self.player.mon.species)
+      HeldItems.onEntry(self, self.player)
     end)
   end)
   self:act(function()
@@ -3098,6 +3109,10 @@ function BattleState:endOfTurn()
   -- (player first, then enemy -- that order is the serial-connection one, not
   -- a speed check).
   Weather.upkeep(self)
+  -- Gen II HandleBetweenTurnEffects reaches held items only after weather and
+  -- the associated faint checks.  HeldItems.endTurn keeps Leftovers, PP and
+  -- healing-item phases in cartridge order and never revives a residual KO.
+  HeldItems.endTurn(self)
   self:tickTokens()
   self:roamerFlees()
   Runtime.emit("battle.turn_ended", { battle = self, turn = self.turnCount or 0 })
@@ -3898,6 +3913,7 @@ function BattleState:executeAction(user, target, action)
       -- _AIBattleWithdrawText: "X with-/drew Y!"
       self:sayNext(Strings("%s with-\ndrew %s!", self.trainer.name, oldName))
       self:sayNext(Strings("%s sent\nout %s!", self.trainer.name, self.enemy.name))
+      HeldItems.onEntry(self, self.enemy)
       return
     end
 
@@ -4641,6 +4657,7 @@ function BattleState:enemyMonFainted()
           self:shinyAnim(self.enemy, true)
           self:actNext(function()
             require("src.core.Sound").playCry(self.data, self.enemy.mon.species)
+            HeldItems.onEntry(self, self.enemy)
           end)
         end)
       end)
@@ -4680,6 +4697,7 @@ function BattleState:enemyMonFainted()
           self.sendingOut = false
           self:startGrowIn(self.player)
           require("src.core.Sound").playCry(self.data, self.player.mon.species)
+          HeldItems.onEntry(self, self.player)
         end)
       end)
       return
@@ -4702,6 +4720,7 @@ function BattleState:enemyMonFainted()
     if require("src.core.GameVersion").isGen2() then
       prize = prize * 4
     end
+    prize = HeldItems.modifyPrize(self, prize)
     self.game.save.money = self.game.save.money + prize
     -- Prism's Spurge Bank ATM (event/bank.asm) offers DIRECT DEPOSIT: with it
     -- enabled, a quarter of what you win in battle is routed to the account
@@ -4908,6 +4927,7 @@ function BattleState:openReplacementMenu()
           -- SendOutMon (core.asm:1757-1762): poof, then the grow-in
           self:startGrowIn(self.player)
           require("src.core.Sound").playCry(self.data, self.player.mon.species)
+          HeldItems.onEntry(self, self.player)
         end)
       end,
     })
@@ -5064,6 +5084,11 @@ end
 -- counts a run attempt each call.  Hooked as battle.run.
 function BattleState:runRoll(pSpd, eSpd)
   self.runAttempts = (self.runAttempts or 0) + 1
+  -- Smoke Ball guarantees escape from a wild battle without consuming the
+  -- ordinary speed/RNG formula.  Trainer battles are rejected by tryRun first.
+  if self.kind ~= "trainer" and HeldItems.canEscape(self.data, self.player) then
+    return true
+  end
   if Runtime.wantsHook("battle.run") then
     local battle = self
     return Runtime.call("battle.run", function(c)

--- a/src/battle/Damage.lua
+++ b/src/battle/Damage.lua
@@ -12,6 +12,7 @@ local Stats = require("src.pokemon.Stats")
 local Status = require("src.battle.Status")
 local TypeChart = require("src.battle.TypeChart")
 local Weather = require("src.battle.Weather")
+local HeldItems = require("src.battle.HeldItems")
 
 local Damage = {}
 
@@ -79,9 +80,25 @@ Damage.stageOf = stageOf
 -- ruleset that sets critStages cannot just tune the Gen 1 numbers.
 local CRIT_STAGE_DEN = { [0] = 16, 8, 4, 3, 2 }
 
-function Damage.critRoll(ruleset, attacker, moveId, rng, highCrit)
+function Damage.critRoll(ruleset, attacker, moveId, rng, highCrit, data)
   rng = rng or love.math.random
   if highCrit == nil then highCrit = HIGH_CRIT[moveId] end
+
+  -- Gen II replaced the speed-derived Gen I test with a fixed 0..255 ladder:
+  -- 17, 32, 64, 85, 128, 255.  High-crit moves add two stages, Focus Energy
+  -- adds one, Scope Lens adds one, and Stick/Lucky Punch add two.  Use explicit
+  -- imported-generation metadata so Gen I and optional Gen III rulesets keep
+  -- their existing behavior.
+  if data and data.constants and data.constants.generation == 2
+     and not ruleset.critMultiplier then
+    local stage = 0
+    if highCrit then stage = stage + 2 end
+    if attacker.focusEnergy then stage = stage + 1 end
+    stage = stage + HeldItems.criticalStageBonus(data, attacker)
+    local chance = ({ [0] = 17, 32, 64, 85, 128, 255 })[math.max(0, math.min(5, stage))]
+    return rng(0, 255) < chance
+  end
+
   if ruleset.critStages then
     local stage = 0
     if highCrit then stage = stage + 1 end
@@ -123,7 +140,7 @@ end
 -- Gen 2's BattleCommand_ThunderAccuracy writes that byte directly
 -- (`ld [hl], 50 percent + 1` = 128), so the caller passes the raw threshold
 -- rather than a percentage: floor(50 * 255 / 100) would be 127, one short.
-function Damage.accuracyRoll(ruleset, move, attacker, defender, rng, accuracyRaw)
+function Damage.accuracyRoll(ruleset, move, attacker, defender, rng, accuracyRaw, data)
   rng = rng or love.math.random
   -- X ACCURACY sets USING_X_ACCURACY: the move simply never misses
   -- (MoveHitTest returns before any accuracy math, 1/256 included)
@@ -136,6 +153,10 @@ function Damage.accuracyRoll(ruleset, move, attacker, defender, rng, accuracyRaw
           attacker.stages and attacker.stages.accuracy or 0))
   acc = math.min(255, Stats.applyStage(acc,
           -(defender.stages and defender.stages.evasion or 0)))
+  -- BrightPowder subtracts its ItemAttributes parameter (20 in retail Gen II)
+  -- from the post-stage threshold.  Zero is a valid result; do not clamp it to
+  -- one, otherwise a 1/256 hit chance is invented.
+  acc = math.max(0, acc - HeldItems.accuracyPenalty(data, defender))
   if not ruleset.oneIn256Miss and basePct >= 100
      and (attacker.stages.accuracy or 0) >= (defender.stages.evasion or 0) then
     return true
@@ -182,11 +203,11 @@ function Damage.compute(ruleset, attacker, defender, move, opts)
   if crit == nil then
     if Runtime.wantsHook("battle.crit") then
       crit = Runtime.call("battle.crit", function(c)
-        return Damage.critRoll(c.ruleset, c.attacker, c.moveId, c.rng, c.highCrit)
+        return Damage.critRoll(c.ruleset, c.attacker, c.moveId, c.rng, c.highCrit, c.data)
       end, { ruleset = ruleset, attacker = attacker, moveId = move.id,
-             rng = rng, highCrit = move.highCrit })
+             rng = rng, highCrit = move.highCrit, data = opts.data })
     else
-      crit = Damage.critRoll(ruleset, attacker, move.id, rng, move.highCrit)
+      crit = Damage.critRoll(ruleset, attacker, move.id, rng, move.highCrit, opts.data)
     end
   end
 
@@ -243,6 +264,12 @@ function Damage.compute(ruleset, attacker, defender, move, opts)
       end
     end
   end
+
+  -- Species-specific Gen II stat items are applied to the battle stats before
+  -- GetDamageVars performs its paired quartering step.
+  atk, dfn = HeldItems.modifyBattleStats(opts.data, attacker, defender,
+                                         atkStat, defStat, atk, dfn)
+
   -- GetDamageVars .scaleStats: when either stat no longer fits a byte,
   -- BOTH are quartered (losing low bits), each bumped to at least 1
   if atk > 255 or dfn > 255 then
@@ -263,6 +290,14 @@ function Damage.compute(ruleset, attacker, defender, move, opts)
   local d = math.floor(math.floor(2 * level / 5) + 2)
   d = math.floor(math.floor(d * move.power * atk / math.max(1, dfn)) / 50)
   d = math.min(d, 997) + 2
+
+  -- Held type boosters live inside BattleCommand_DamageCalc, before weather,
+  -- STAB and effectiveness.  This placement matters because every stage floors
+  -- independently.  HeldItems applies the recomp's intentional Gen II cleanup
+  -- for the retail Dragon Fang/Dragon Scale held-effect data bug.
+  if not opts.typeless then
+    d = HeldItems.applyTypeBoost(opts.data, attacker, move.type, d)
+  end
 
   -- DoWeatherModifiers (engine/battle/misc.asm:52) runs at the head of
   -- AdjustDamageForMoveType -- BEFORE STAB and before type effectiveness --

--- a/src/battle/EffectRegistry.lua
+++ b/src/battle/EffectRegistry.lua
@@ -11,6 +11,7 @@ local Runtime = require("src.mods.Runtime")
 local StatusRegistry = require("src.battle.StatusRegistry")
 local Strings = require("src.core.Strings")
 local Timing = require("src.core.Timing")
+local HeldItems = require("src.battle.HeldItems")
 
 local EffectRegistry = {}
 
@@ -211,6 +212,9 @@ function EffectRegistry.runDamaging(battle, ctx, record)
     if record and record.onMiss then record.onMiss(ctx, "floored") end
     return
   end
+  -- Focus Band belongs to the direct-damage seam below.  It is evaluated per
+  -- damaging strike so a later hit of a multi-hit move can save a battler once
+  -- that particular strike becomes lethal; Substitute never consumes its RNG.
   battle.lastDamage = dmg -- wDamage (shared by both sides, read by Counter)
 
   -- the hit blink + damage sound ride each animation row, placed BEFORE
@@ -251,7 +255,14 @@ function EffectRegistry.runDamaging(battle, ctx, record)
       table.insert(battle.queue, battle.nextInsert, hitRow)
     end
     local hadSub = target.substituteHP ~= nil
-    local dealt = battle:applyDamage(target, dmg)
+    local hitDamage = dmg
+    if not hadSub then
+      -- This seam is reached only by direct attack damage. Weather, poison,
+      -- Leech Seed and confusion self-hit never roll Focus Band here.
+      hitDamage = HeldItems.limitDirectDamage(battle.data, target, hitDamage, battle.rng)
+    end
+    battle.lastDamage = hitDamage
+    local dealt = battle:applyDamage(target, hitDamage)
     totalDealt = totalDealt + dealt
     landed = h
     if dealt > 0 then hitRow.hit = hitFx end
@@ -316,6 +327,19 @@ function EffectRegistry.runDamaging(battle, ctx, record)
   end
   if record == nil then
     MoveEffects.warnUnknown(move.effect)
+  end
+
+  -- King's Rock is an explicit command in selected Gen II move scripts.  It
+  -- rolls once after the completed attack (not once per hit) and cannot pass a
+  -- Substitute.  Some native-flinch scripts (notably Sky Attack and Snore)
+  -- also execute King's Rock, so HeldItems decides eligibility from the move
+  -- effect rather than suppressing all flinch-capable moves.
+  if totalDealt > 0 and target.mon.hp > 0 then
+    -- BattleCommand_KingsRock checks the target's Substitute at the point the
+    -- command runs.  If an earlier hit broke the Substitute, the held-item
+    -- flinch is therefore allowed.
+    HeldItems.tryKingsRock(battle.data, user, target, move, battle.rng,
+                           target.substituteHP ~= nil)
   end
 
   if target.mon.hp <= 0 then

--- a/src/battle/Experience.lua
+++ b/src/battle/Experience.lua
@@ -7,6 +7,7 @@
 local Growth = require("src.pokemon.Growth")
 local Runtime = require("src.mods.Runtime")
 local Stats = require("src.pokemon.Stats")
+local HeldItems = require("src.battle.HeldItems")
 
 local Experience = {}
 
@@ -71,6 +72,8 @@ function Experience.apply(data, mon, defeatedDef, level, isTrainer,
     gained = Experience.gainFor(defeatedDef, level, isTrainer,
                                 numParticipants, traded, consts)
   end
+  -- Lucky Egg is a per-recipient x1.5 held-item boost in Generation II.
+  gained = HeldItems.modifyExperience(data, mon, gained)
   mon.exp = mon.exp + gained
 
   local cap = consts and consts.levelCap or 100

--- a/src/battle/HeldItems.lua
+++ b/src/battle/HeldItems.lua
@@ -1,0 +1,511 @@
+-- Generation II held-item mechanics shared by battle and field seams.
+--
+-- The Gen2 ROM extractor stamps ItemAttributes' held-effect byte and signed
+-- parameter onto each item record.  Most mechanics can therefore follow the
+-- cartridge's data rather than maintain a second item-name table.  The few
+-- species-specific items whose ItemAttributes effect is HELD_NONE (Thick Club,
+-- Light Ball, Lucky Punch, Lucky Egg and Berserk Gene) are identified by key.
+
+local ItemEffects = require("src.inventory.ItemEffects")
+local Strings = require("src.core.Strings")
+
+local HeldItems = {}
+
+HeldItems.EFFECT = {
+  NONE = 0,
+  BERRY = 1,
+  LEFTOVERS = 3,
+  RESTORE_PP = 6,
+  CLEANSE_TAG = 8,
+  HEAL_POISON = 10,
+  HEAL_FREEZE = 11,
+  HEAL_BURN = 12,
+  HEAL_SLEEP = 13,
+  HEAL_PARALYZE = 14,
+  HEAL_STATUS = 15,
+  HEAL_CONFUSION = 16,
+  METAL_POWDER = 42,
+  NORMAL_BOOST = 50,
+  FIGHTING_BOOST = 51,
+  FLYING_BOOST = 52,
+  POISON_BOOST = 53,
+  GROUND_BOOST = 54,
+  ROCK_BOOST = 55,
+  BUG_BOOST = 56,
+  GHOST_BOOST = 57,
+  FIRE_BOOST = 58,
+  WATER_BOOST = 59,
+  GRASS_BOOST = 60,
+  ELECTRIC_BOOST = 61,
+  PSYCHIC_BOOST = 62,
+  ICE_BOOST = 63,
+  DRAGON_BOOST = 64,
+  DARK_BOOST = 65,
+  STEEL_BOOST = 66,
+  ESCAPE = 72,
+  CRITICAL_UP = 73,
+  QUICK_CLAW = 74,
+  FLINCH = 75,
+  AMULET_COIN = 76,
+  BRIGHTPOWDER = 77,
+  FOCUS_BAND = 79,
+}
+
+local TYPE_BY_EFFECT = {
+  [50] = "NORMAL", [51] = "FIGHTING", [52] = "FLYING",
+  [53] = "POISON", [54] = "GROUND", [55] = "ROCK", [56] = "BUG",
+  [57] = "GHOST", [58] = "FIRE", [59] = "WATER", [60] = "GRASS",
+  [61] = "ELECTRIC", [62] = "PSYCHIC", [63] = "ICE", [64] = "DRAGON",
+  [65] = "DARK", [66] = "STEEL",
+}
+
+local STATUS_BY_EFFECT = {
+  [HeldItems.EFFECT.HEAL_POISON] = "PSN",
+  [HeldItems.EFFECT.HEAL_FREEZE] = "FRZ",
+  [HeldItems.EFFECT.HEAL_BURN] = "BRN",
+  [HeldItems.EFFECT.HEAL_SLEEP] = "SLP",
+  [HeldItems.EFFECT.HEAL_PARALYZE] = "PAR",
+}
+
+local function norm(value)
+  if value == nil then return nil end
+  local key = tostring(value):upper():gsub("[%.']", "")
+  key = key:gsub("[^A-Z0-9]+", "_"):gsub("^_+", ""):gsub("_+$", "")
+  local aliases = {
+    KING_S_ROCK = "KINGS_ROCK",
+    MYSTERYBERRY = "MYSTERY_BERRY",
+    MIRACLEBERRY = "MIRACLE_BERRY",
+    SILVERPOWDER = "SILVER_POWDER",
+    TWISTEDSPOON = "TWISTED_SPOON",
+    NEVERMELTICE = "NEVER_MELT_ICE",
+    BLACKGLASSES = "BLACK_GLASSES",
+    FARFETCH_D = "FARFETCHD",
+  }
+  return aliases[key] or key
+end
+HeldItems.norm = norm
+
+local function monOf(holder)
+  return holder and (holder.mon or holder) or nil
+end
+
+local function itemDef(data, holder)
+  local mon = monOf(holder)
+  local id = mon and (mon.item or mon.heldItem)
+  if not (id and data and data.items) then return nil, id end
+  return data.items[id], id
+end
+
+function HeldItems.itemKey(data, holder)
+  local def, id = itemDef(data, holder)
+  if not id then return nil end
+  local key = ItemEffects.alias(id, def)
+  return norm(key or (def and (def.key or def.name)) or id)
+end
+
+function HeldItems.effect(data, holder)
+  local def, id = itemDef(data, holder)
+  if type(def) ~= "table" then return HeldItems.EFFECT.NONE, 0 end
+
+  -- Intentional Gen II cleanup approved for the recomp ruleset: retail
+  -- Crystal accidentally assigns HELD_DRAGON_BOOST to Dragon Scale and leaves
+  -- Dragon Fang with HELD_NONE.  Treat Dragon Fang as the Dragon-type booster
+  -- and Dragon Scale as a normal held item instead of reproducing that bug.
+  local key = norm(ItemEffects.alias(id, def) or def.key or def.name or id)
+  if key == "DRAGON_FANG" then
+    return HeldItems.EFFECT.DRAGON_BOOST, 10
+  elseif key == "DRAGON_SCALE" then
+    return HeldItems.EFFECT.NONE, 0
+  end
+
+  return tonumber(def.heldEffect) or HeldItems.EFFECT.NONE,
+         tonumber(def.heldParam) or 0
+end
+
+local function speciesKey(holder)
+  local mon = monOf(holder)
+  return norm(mon and mon.species)
+end
+
+local function consume(holder)
+  local mon = monOf(holder)
+  if not mon then return end
+  mon.item, mon.heldItem = nil, nil
+end
+HeldItems.consume = consume
+
+local function isAlive(holder)
+  local mon = monOf(holder)
+  return mon and (tonumber(mon.hp) or 0) > 0
+end
+
+local function heal(holder, amount)
+  local mon = monOf(holder)
+  local maxHP = mon and mon.stats and tonumber(mon.stats.hp)
+  if not (mon and maxHP and tonumber(mon.hp)) or mon.hp <= 0 or mon.hp >= maxHP then
+    return 0
+  end
+  local before = mon.hp
+  mon.hp = math.min(maxHP, mon.hp + math.max(1, math.floor(amount or 0)))
+  return mon.hp - before
+end
+
+local function displayName(holder)
+  if not holder then return "POKéMON" end
+  if holder.name then return holder.isPlayer == false and ("Enemy " .. holder.name) or holder.name end
+  local mon = monOf(holder)
+  return mon and (mon.nickname or mon.species) or "POKéMON"
+end
+
+local function queueHeal(battle, holder, text)
+  if text then battle:sayNext(Strings(text, displayName(holder))) end
+  local mon = monOf(holder)
+  if battle.drainNext and mon then battle:drainNext(holder, mon.hp) end
+end
+
+-- -------------------------------------------------------------------------
+-- Turn order / hit chance / critical chance
+-- -------------------------------------------------------------------------
+
+function HeldItems.quickClaw(data, holder, rng)
+  local effect, param = HeldItems.effect(data, holder)
+  if effect ~= HeldItems.EFFECT.QUICK_CLAW then return false end
+  rng = rng or love.math.random
+  return rng(0, 255) < param
+end
+
+function HeldItems.accuracyPenalty(data, holder)
+  local effect, param = HeldItems.effect(data, holder)
+  return effect == HeldItems.EFFECT.BRIGHTPOWDER and param or 0
+end
+
+function HeldItems.criticalStageBonus(data, holder)
+  local effect = HeldItems.effect(data, holder)
+  if effect == HeldItems.EFFECT.CRITICAL_UP then return 1 end
+  local key, species = HeldItems.itemKey(data, holder), speciesKey(holder)
+  if key == "STICK" and species == "FARFETCHD" then return 2 end
+  if key == "LUCKY_PUNCH" and species == "CHANSEY" then return 2 end
+  return 0
+end
+
+-- -------------------------------------------------------------------------
+-- Damage/stat held items
+-- -------------------------------------------------------------------------
+
+function HeldItems.modifyBattleStats(data, attacker, defender, atkStat, defStat, atk, dfn)
+  local aKey, aSpecies = HeldItems.itemKey(data, attacker), speciesKey(attacker)
+  local dEffect = HeldItems.effect(data, defender)
+  local dSpecies = speciesKey(defender)
+
+  if aKey == "THICK_CLUB" and (aSpecies == "CUBONE" or aSpecies == "MAROWAK")
+     and atkStat == "attack" then
+    atk = atk * 2
+  elseif aKey == "LIGHT_BALL" and aSpecies == "PIKACHU"
+     and (atkStat == "spatk" or atkStat == "special") then
+    atk = atk * 2
+  end
+
+  -- A transformed Ditto keeps mon.species = DITTO while battler.species is the
+  -- copied species.  Metal Powder only works before Transform.
+  local untransformedDitto = dSpecies == "DITTO"
+    and (defender.species == nil or norm(defender.species) == "DITTO")
+  if dEffect == HeldItems.EFFECT.METAL_POWDER and untransformedDitto
+     and (defStat == "defense" or defStat == "spdef" or defStat == "special") then
+    dfn = math.floor(dfn * 3 / 2)
+  end
+  return atk, dfn
+end
+
+function HeldItems.applyTypeBoost(data, attacker, moveType, damage)
+  local effect, param = HeldItems.effect(data, attacker)
+  if TYPE_BY_EFFECT[effect] ~= moveType then return damage end
+  -- ItemAttributes stores 10 for the retail type boosters: x1.10, with the
+  -- floor occurring here inside the damage pipeline.
+  return math.max(1, math.floor(damage * (100 + param) / 100))
+end
+
+function HeldItems.limitDirectDamage(data, target, damage, rng)
+  if not isAlive(target) or damage <= 0 then return damage end
+  local effect, param = HeldItems.effect(data, target)
+  if effect ~= HeldItems.EFFECT.FOCUS_BAND then return damage end
+  local hp = tonumber(monOf(target).hp) or 0
+  if hp <= 1 or damage < hp then return damage end
+  rng = rng or love.math.random
+  if rng(0, 255) < param then return hp - 1 end
+  return damage
+end
+
+-- Crystal does not run BattleCommand_KingsRock after every damaging move.
+-- It is an explicit command in selected move-effect scripts (NormalHit,
+-- LeechHit, MultiHit, RecoilHit, SkyAttack, Snore, etc.).  Keep that script
+-- boundary here instead of approximating it from power or from whether a move
+-- already has a native flinch chance.  In particular Sky Attack and Snore
+-- really execute BOTH flinchtarget and kingsrock on cartridge.
+local KINGS_ROCK_EFFECTS = {
+  NO_ADDITIONAL_EFFECT = true,
+  SWIFT_EFFECT = true,
+  DRAIN_HP_EFFECT = true,
+  EXPLODE_EFFECT = true,
+  PAY_DAY_EFFECT = true,
+  BIDE_EFFECT = true,
+  THRASH_PETAL_DANCE_EFFECT = true,
+  TWO_TO_FIVE_ATTACKS_EFFECT = true,
+  ATTACK_TWICE_EFFECT = true,
+  JUMP_KICK_EFFECT = true,
+  TWINEEDLE_EFFECT = true,
+  RECOIL_EFFECT = true,
+  CHARGE_EFFECT = true,
+  RAGE_EFFECT = true,
+  FLY_EFFECT = true,
+  SUPER_FANG_EFFECT = true,
+  SPECIAL_DAMAGE_EFFECT = true,
+  REVERSAL_EFFECT = true,
+  COUNTER_EFFECT = true,
+  SNORE_EFFECT = true,
+  FALSE_SWIPE_EFFECT = true,
+  THIEF_EFFECT = true,
+  ROLLOUT_EFFECT = true,
+  FURY_CUTTER_EFFECT = true,
+  RETURN_EFFECT = true,
+  PRESENT_EFFECT = true,
+  FRUSTRATION_EFFECT = true,
+  MAGNITUDE_EFFECT = true,
+  PURSUIT_EFFECT = true,
+  RAPID_SPIN_EFFECT = true,
+  HIDDEN_POWER_EFFECT = true,
+  MIRROR_COAT_EFFECT = true,
+  SOLARBEAM_EFFECT = true,
+  BEAT_UP_EFFECT = true,
+}
+
+function HeldItems.supportsKingsRock(move)
+  if not move then return false end
+  -- Triple Kick has its own Crystal effect byte, but the importer represents
+  -- its three-hit semantics through move.multiHit instead of a separate effect
+  -- name.  Its script ends in `kingsrock` just like the other eligible moves.
+  if norm(move.id) == "TRIPLE_KICK" or tonumber(move.multiHit) == 3 then
+    return true
+  end
+  return KINGS_ROCK_EFFECTS[norm(move.effect)] == true
+end
+
+function HeldItems.tryKingsRock(data, user, target, move, rng, blockedBySubstitute)
+  if blockedBySubstitute or not isAlive(target) or not HeldItems.supportsKingsRock(move) then
+    return false
+  end
+  local effect, param = HeldItems.effect(data, user)
+  if effect ~= HeldItems.EFFECT.FLINCH then return false end
+  rng = rng or love.math.random
+  if rng(0, 255) < param then
+    target.flinched = true
+    return true
+  end
+  return false
+end
+
+-- -------------------------------------------------------------------------
+-- Automatic consumables
+-- -------------------------------------------------------------------------
+
+-- Gen II keeps one confusion counter per battle side, separate from the
+-- active party struct.  Switching therefore leaves the previous counter
+-- behind.  Ordinary confusion effects initialize this counter explicitly;
+-- Berserk Gene does the same here as an intentional correction of Crystal's
+-- retail 256-turn/stale-counter bug.
+local function confusionSide(holder)
+  return holder and holder.isPlayer and "player" or "enemy"
+end
+
+function HeldItems.setConfusionCounter(battle, holder, turns)
+  if not (battle and holder) then return end
+  battle.heldConfusionCounters = battle.heldConfusionCounters or {}
+  battle.heldConfusionCounters[confusionSide(holder)] = math.max(0, tonumber(turns) or 0)
+end
+
+function HeldItems.confusionCounter(battle, holder)
+  local counters = battle and battle.heldConfusionCounters
+  return counters and (tonumber(counters[confusionSide(holder)]) or 0) or 0
+end
+
+local function curePersistent(holder, wanted)
+  local mon = monOf(holder)
+  local status = mon and mon.status
+  if not status then return false end
+  if wanted and norm(status) ~= wanted then return false end
+  mon.status = nil
+  holder.sleepTurns, holder.toxicCounter = nil, nil
+  return true
+end
+
+function HeldItems.onStatus(battle, holder)
+  if not (battle and isAlive(holder)) then return {} end
+  local effect = HeldItems.effect(battle.data, holder)
+  local wanted = STATUS_BY_EFFECT[effect]
+  local changed = false
+  if wanted then
+    changed = curePersistent(holder, wanted)
+  elseif effect == HeldItems.EFFECT.HEAL_STATUS then
+    changed = curePersistent(holder)
+    -- MiracleBerry cures every major status at once, including confusion.
+    -- If a primary status triggered it while confusion is also active, clear
+    -- both before consuming the item rather than leaving confusion behind.
+    if changed then
+      holder.confusedTurns = nil
+      HeldItems.setConfusionCounter(battle, holder, 0)
+    end
+  end
+  if not changed then return {} end
+  consume(holder)
+  holder.shownStatus = holder.mon.status
+  return { Strings("%s's held item\ncured its status!", displayName(holder)) }
+end
+
+function HeldItems.onConfusion(battle, holder)
+  if not (battle and isAlive(holder)) or not holder.confusedTurns then return {} end
+  local effect = HeldItems.effect(battle.data, holder)
+  local key = HeldItems.itemKey(battle.data, holder)
+  if effect ~= HeldItems.EFFECT.HEAL_CONFUSION
+     and effect ~= HeldItems.EFFECT.HEAL_STATUS
+     and key ~= "BITTER_BERRY" and key ~= "MIRACLE_BERRY" then
+    return {}
+  end
+  holder.confusedTurns = nil
+  HeldItems.setConfusionCounter(battle, holder, 0)
+  consume(holder)
+  return { Strings("%s snapped out\nwith its held item!", displayName(holder)) }
+end
+
+local function restorePP(data, holder)
+  local mon = monOf(holder)
+  for i, move in ipairs(mon and mon.moves or {}) do
+    if (tonumber(move.pp) or 0) <= 0 then
+      local def = data.moves and data.moves[move.id]
+      local base = def and tonumber(def.pp)
+      local maxPP = base
+      if base then maxPP = base + (tonumber(move.ppUps) or 0) * math.floor(base / 5) end
+      local amount = norm(move.id) == "SKETCH" and 1 or 5
+      move.pp = maxPP and math.min(maxPP, amount) or amount
+      if holder.curMoves and holder.curMoves ~= mon.moves and holder.curMoves[i] then
+        holder.curMoves[i].pp = move.pp
+      end
+      return true
+    end
+  end
+  return false
+end
+
+local function processLeftovers(battle, holder)
+  if not isAlive(holder) then return end
+  local effect = HeldItems.effect(battle.data, holder)
+  if effect ~= HeldItems.EFFECT.LEFTOVERS then return end
+  local mon = monOf(holder)
+  local maxHP = mon.stats and tonumber(mon.stats.hp)
+  if not maxHP then return end
+  local got = heal(holder, math.max(1, math.floor(maxHP / 16)))
+  if got > 0 then
+    queueHeal(battle, holder, "%s restored HP\nwith LEFTOVERS!")
+  end
+end
+
+local function processRestorePP(battle, holder)
+  if not isAlive(holder) then return end
+  local effect = HeldItems.effect(battle.data, holder)
+  if effect == HeldItems.EFFECT.RESTORE_PP and restorePP(battle.data, holder) then
+    consume(holder)
+    battle:sayNext(Strings("%s's held item\nrestored PP!", displayName(holder)))
+  end
+end
+
+local function processHealingItem(battle, holder)
+  if not isAlive(holder) then return end
+  local effect, param = HeldItems.effect(battle.data, holder)
+  local mon = monOf(holder)
+  if effect == HeldItems.EFFECT.BERRY then
+    local maxHP = mon.stats and tonumber(mon.stats.hp)
+    if maxHP and mon.hp * 2 <= maxHP then
+      local got = heal(holder, param)
+      if got > 0 then
+        consume(holder)
+        queueHeal(battle, holder, "%s restored HP\nwith its held item!")
+      end
+    end
+    return
+  end
+
+  -- Status berries normally fire as soon as the condition is inflicted.  This
+  -- fallback mirrors HandleHealingItems for a status that entered through an
+  -- older/non-standard seam.
+  local msgs = HeldItems.onStatus(battle, holder)
+  if #msgs == 0 then msgs = HeldItems.onConfusion(battle, holder) end
+  for _, msg in ipairs(msgs) do battle:sayNext(msg) end
+end
+
+-- HandleBetweenTurnEffects reaches held items only after weather and its faint
+-- checks.  Keep the item phases grouped rather than processing every item on
+-- one battler at once: cartridge order is Leftovers, MysteryBerry, then the
+-- healing/status-item family.
+function HeldItems.endTurn(battle)
+  if not battle or battle.result then return end
+  local battlers = { battle.player, battle.enemy }
+  for _, b in ipairs(battlers) do processLeftovers(battle, b) end
+  for _, b in ipairs(battlers) do processRestorePP(battle, b) end
+  for _, b in ipairs(battlers) do processHealingItem(battle, b) end
+end
+
+-- Berserk Gene is HELD_NONE in ItemAttributes and is detected by key.
+-- Crystal retail leaves the side confusion counter uninitialized, causing a
+-- stale-counter/256-turn bug.  This implementation intentionally corrects
+-- that legacy bug by initializing a normal Gen II confusion duration.
+function HeldItems.onEntry(battle, holder)
+  if not (battle and isAlive(holder)) then return false end
+  if HeldItems.itemKey(battle.data, holder) ~= "BERSERK_GENE" then return false end
+  consume(holder)
+  holder.stages = holder.stages or {}
+  holder.stages.attack = math.min(6, (tonumber(holder.stages.attack) or 0) + 2)
+  holder.confusedTurns = battle.rng(2, 5)
+  HeldItems.setConfusionCounter(battle, holder, holder.confusedTurns)
+  battle:sayNext(Strings("%s's BERSERK GENE\nsharply raised ATTACK!", displayName(holder)))
+  return true
+end
+
+-- -------------------------------------------------------------------------
+-- EXP / prize money / escape / encounter rate
+-- -------------------------------------------------------------------------
+
+function HeldItems.modifyExperience(data, mon, gained)
+  if HeldItems.itemKey(data, mon) == "LUCKY_EGG" then
+    return math.max(1, math.floor(gained * 3 / 2))
+  end
+  return gained
+end
+
+function HeldItems.observeParticipant(battle, holder)
+  if battle and holder and holder.isPlayer then
+    local effect = HeldItems.effect(battle.data, holder)
+    if effect == HeldItems.EFFECT.AMULET_COIN then battle.amuletCoin = true end
+  end
+end
+
+function HeldItems.modifyPrize(battle, prize)
+  return battle and battle.amuletCoin and prize * 2 or prize
+end
+
+function HeldItems.canEscape(data, holder)
+  local effect = HeldItems.effect(data, holder)
+  return effect == HeldItems.EFFECT.ESCAPE
+end
+
+-- Crystal scans the whole party for Cleanse Tag, then halves the encounter
+-- rate byte before the first encounter RNG draw.  The holder does not need to
+-- be in slot one (ApplyCleanseTagEffectOnEncounterRate loops wPartyCount).
+function HeldItems.cleanseTagRate(data, party, rate)
+  for _, mon in ipairs(party or {}) do
+    local effect = HeldItems.effect(data, mon)
+    if effect == HeldItems.EFFECT.CLEANSE_TAG then
+      return math.floor((tonumber(rate) or 0) / 2)
+    end
+  end
+  return rate
+end
+
+return HeldItems

--- a/src/battle/MoveEffects.lua
+++ b/src/battle/MoveEffects.lua
@@ -16,6 +16,7 @@ local StatusRegistry = require("src.battle.StatusRegistry")
 local TurnOrder = require("src.battle.TurnOrder")
 local TypeChart = require("src.battle.TypeChart")
 local Strings = require("src.core.Strings")
+local HeldItems = require("src.battle.HeldItems")
 local Weather = require("src.battle.Weather")
 
 local MoveEffects = {}
@@ -150,7 +151,12 @@ local function confuse(battle, target, pierceSub)
     return { Strings("But, it failed!") }
   end
   target.confusedTurns = battle.rng(2, 5)
-  return { Strings("%s\nbecame confused!", displayName(target)) }
+  HeldItems.setConfusionCounter(battle, target, target.confusedTurns)
+  local msgs = { Strings("%s\nbecame confused!", displayName(target)) }
+  for _, msg in ipairs(HeldItems.onConfusion(battle, target)) do
+    msgs[#msgs + 1] = msg
+  end
+  return msgs
 end
 
 -- ---------------------------------------------------------------------
@@ -257,6 +263,7 @@ MoveEffects.primary = {
     for _, b in ipairs({ user, target }) do
       b.stages = {}
       b.confusedTurns = nil
+      HeldItems.setConfusionCounter(battle, b, 0)
       b.leechSeeded = nil
       b.toxicCounter = nil
       b.reflect, b.lightScreen, b.mist, b.focusEnergy = nil, nil, nil, nil
@@ -599,7 +606,11 @@ MoveEffects.full = {
           user.thrashTurns, user.thrashMove, user.thrashAnnounced = nil, nil, nil
           if not user.confusedTurns then
             user.confusedTurns = ctx.rng(2, 5)
+            HeldItems.setConfusionCounter(ctx.battle, user, user.confusedTurns)
             ctx.say(Strings("%s\nbecame confused!", displayName(user)))
+            for _, msg in ipairs(HeldItems.onConfusion(ctx.battle, user)) do
+              ctx.say(msg)
+            end
           end
         end
       end

--- a/src/battle/Status.lua
+++ b/src/battle/Status.lua
@@ -6,6 +6,7 @@
 -- back to the vanilla records, which is bit-identical behavior.
 
 local Strings = require("src.core.Strings")
+local HeldItems = require("src.battle.HeldItems")
 
 local Status = {}
 
@@ -196,8 +197,10 @@ function Status.beforeMove(battler, rng, battle)
   end
   if battler.confusedTurns then
     battler.confusedTurns = battler.confusedTurns - 1
+    HeldItems.setConfusionCounter(battle, battler, battler.confusedTurns)
     if battler.confusedTurns <= 0 then
       battler.confusedTurns = nil
+      HeldItems.setConfusionCounter(battle, battler, 0)
       table.insert(msgs, Strings("%s\nsnapped out of\nconfusion!", name(battler)))
     else
       table.insert(msgs, Strings("%s\nis confused!", name(battler)))

--- a/src/battle/StatusRegistry.lua
+++ b/src/battle/StatusRegistry.lua
@@ -6,6 +6,7 @@
 local Runtime = require("src.mods.Runtime")
 local Status = require("src.battle.Status")
 local Strings = require("src.core.Strings")
+local HeldItems = require("src.battle.HeldItems")
 
 local StatusRegistry = {}
 
@@ -52,6 +53,11 @@ function StatusRegistry.inflict(battle, target, status, opts)
   Runtime.emit("battle.status_inflicted", {
     battle = battle, target = target, status = status, source = opts.source,
   })
+  -- Gen II status berries resolve immediately after the condition lands.
+  -- Keep the infliction text first, then append the held-item cure line.
+  for _, msg in ipairs(HeldItems.onStatus(battle, target)) do
+    msgs[#msgs + 1] = msg
+  end
   return msgs
 end
 

--- a/src/battle/TurnOrder.lua
+++ b/src/battle/TurnOrder.lua
@@ -6,6 +6,7 @@
 local Damage = require("src.battle.Damage")
 local Stats = require("src.pokemon.Stats")
 local Status = require("src.battle.Status")
+local HeldItems = require("src.battle.HeldItems")
 
 local TurnOrder = {}
 
@@ -47,10 +48,27 @@ end
 -- the coin-flip result only: lockstep link battles share one RNG
 -- stream, so the guest inverts the tie roll to agree with the host on
 -- who moves first.
-function TurnOrder.firstMover(a, aMove, b, bMove, rng, invertTie)
+function TurnOrder.firstMover(a, aMove, b, bMove, rng, invertTie, data)
   rng = rng or love.math.random
   local pa, pb = priority(aMove), priority(bMove)
   if pa ~= pb then return pa > pb end
+
+  -- BattleCommand_CheckTurn/Quick Claw: priority classes are resolved first.
+  -- When both holders have Quick Claw, the cartridge checks them serially and
+  -- the first successful roll wins immediately; it does NOT roll both and fall
+  -- back to Speed when both would have succeeded.  invertTie also provides the
+  -- link guest's mirrored ordering so peers consume the shared stream in a
+  -- complementary order.
+  local first, second = a, b
+  local firstIsA = true
+  if invertTie then first, second, firstIsA = b, a, false end
+  if HeldItems.effect(data, first) == HeldItems.EFFECT.QUICK_CLAW then
+    if HeldItems.quickClaw(data, first, rng) then return firstIsA end
+  end
+  if HeldItems.effect(data, second) == HeldItems.EFFECT.QUICK_CLAW then
+    if HeldItems.quickClaw(data, second, rng) then return not firstIsA end
+  end
+
   local sa, sb = effectiveSpeed(a), effectiveSpeed(b)
   if sa ~= sb then return sa > sb end
   local aFirst = rng(0, 1) == 0

--- a/src/import/RomExtractorGen2.lua
+++ b/src/import/RomExtractorGen2.lua
@@ -946,6 +946,9 @@ local GEN2_BADGES = {
 function RomExtractorGen2:constants()
   if not self._constants then
     self._constants = self:readSourceTable("constants")
+    -- Generation is runtime metadata, not cartridge data.  Battle formulas use
+    -- it to select the Gen II critical-hit ladder without guessing from a ROM id.
+    self._constants.generation = 2
     local badges = {}
     -- A CARTRIDGE MAY HAVE ITS OWN SET.  Prism awards TWENTY badges across
     -- three engine-flag bytes, and its flag keys keep the ENGINE_ prefix that
@@ -2346,6 +2349,19 @@ function RomExtractorGen2:extractScaffoldCore()
             local row = attrs.address + (entry.index - 1) * GEN2_ITEM_ATTR_BYTES
             local ok, price = pcall(function() return self.rom:word(attrs.bank, row) end)
             if ok and type(price) == "number" then entry.price = price end
+            -- constants/item_data_constants.asm: ItemAttributes stores the
+            -- held-effect selector at +2 and its signed parameter at +3.
+            -- Keep both on the item record so battle/field mechanics remain
+            -- data-driven.  The battle held-item layer contains the one
+            -- intentional Gen II cleanup for Dragon Fang/Dragon Scale.
+            local oke, heldEffect = pcall(function()
+              return self.rom:byte(attrs.bank, row + 2)
+            end)
+            if oke then entry.heldEffect = heldEffect end
+            local okh, heldParam = pcall(function()
+              return self.rom:byte(attrs.bank, row + 3)
+            end)
+            if okh then entry.heldParam = signedByte(heldParam) end
             local okp, pocket = pcall(function()
               return self.rom:byte(attrs.bank, row + 5)
             end)

--- a/src/link/LinkBattle.lua
+++ b/src/link/LinkBattle.lua
@@ -21,6 +21,7 @@ local Logger = require("src.core.Logger")
 local Protocol = require("src.link.Protocol")
 local Runtime = require("src.mods.Runtime")
 local TurnOrder = require("src.battle.TurnOrder")
+local HeldItems = require("src.battle.HeldItems")
 local Strings = require("src.core.Strings")
 
 local LinkBattle = {}
@@ -152,16 +153,16 @@ local function volStr(b)
 end
 
 local function activeStr(b)
-  return ("%s:%d:%s:%s:%s"):format(b.mon.species, b.mon.hp,
-                                   tostring(b.mon.status), stageStr(b),
-                                   ppStr(b.mon))
+  return ("%s:%d:%s:%s:%s:%s"):format(b.mon.species, b.mon.hp,
+                                      tostring(b.mon.status), tostring(b.mon.item),
+                                      stageStr(b), ppStr(b.mon))
 end
 
 local function benchStr(party)
   local out = {}
   for i, mon in ipairs(party or {}) do
-    out[i] = ("%s:%d:%s"):format(tostring(mon.species), mon.hp or 0,
-                                 tostring(mon.status))
+    out[i] = ("%s:%d:%s:%s"):format(tostring(mon.species), mon.hp or 0,
+                                    tostring(mon.status), tostring(mon.item))
   end
   return table.concat(out, "|")
 end
@@ -305,6 +306,7 @@ function LinkBattle.new(game, net, opts)
       s.sendingOut = false
       s:startGrowIn(s.player)
       require("src.core.Sound").playCry(s.data, s.player.mon.species)
+      HeldItems.onEntry(s, s.player)
     end)
   end
 
@@ -323,6 +325,7 @@ function LinkBattle.new(game, net, opts)
       s:startGrowIn(s.enemy)
       s:actNext(function()
         require("src.core.Sound").playCry(s.data, s.enemy.mon.species)
+        HeldItems.onEntry(s, s.enemy)
       end)
     end)
   end
@@ -426,12 +429,12 @@ function LinkBattle.new(game, net, opts)
         local myMove, theirMove = orderMove(myAction), orderMove(theirAction)
         if Runtime.wantsHook("battle.turn_order") then
           first = Runtime.call("battle.turn_order", function(a, aMove, b, bMove, c)
-            return TurnOrder.firstMover(a, aMove, b, bMove, c.rng, c.invertTie)
+            return TurnOrder.firstMover(a, aMove, b, bMove, c.rng, c.invertTie, c.data)
           end, s.player, myMove, s.enemy, theirMove,
-             { rng = s.rng, invertTie = role == "guest" })
+             { rng = s.rng, invertTie = role == "guest", data = s.data })
         else
           first = TurnOrder.firstMover(s.player, myMove, s.enemy, theirMove,
-                                       s.rng, role == "guest")
+                                       s.rng, role == "guest", s.data)
         end
         local order
         if first then
@@ -749,6 +752,7 @@ function LinkBattle.newSpectator(game, net, opts)
       s.sendingOut = false
       s:startGrowIn(s.player)
       require("src.core.Sound").playCry(s.data, s.player.mon.species)
+      HeldItems.onEntry(s, s.player)
     end)
   end
 
@@ -766,6 +770,7 @@ function LinkBattle.newSpectator(game, net, opts)
       s:startGrowIn(s.enemy)
       s:actNext(function()
         require("src.core.Sound").playCry(s.data, s.enemy.mon.species)
+        HeldItems.onEntry(s, s.enemy)
       end)
     end)
   end
@@ -809,10 +814,12 @@ function LinkBattle.newSpectator(game, net, opts)
         local first
         if Runtime.wantsHook("battle.turn_order") then
           first = Runtime.call("battle.turn_order", function(a, aMove, b, bMove, c)
-            return TurnOrder.firstMover(a, aMove, b, bMove, c.rng, c.invertTie)
-          end, s.player, hostMove, s.enemy, guestMove, { rng = s.rng, invertTie = false })
+            return TurnOrder.firstMover(a, aMove, b, bMove, c.rng, c.invertTie, c.data)
+          end, s.player, hostMove, s.enemy, guestMove,
+             { rng = s.rng, invertTie = false, data = s.data })
         else
-          first = TurnOrder.firstMover(s.player, hostMove, s.enemy, guestMove, s.rng, false)
+          first = TurnOrder.firstMover(s.player, hostMove, s.enemy, guestMove,
+                                       s.rng, false, s.data)
         end
         local order
         if first then

--- a/src/world/Encounter.lua
+++ b/src/world/Encounter.lua
@@ -19,12 +19,13 @@ function Encounter.load(data)
   buckets = FieldDefaults.constant(data, "encounterBuckets")
 end
 
-function Encounter.roll(encounterDef, rng)
+function Encounter.roll(encounterDef, rng, rateOverride)
   rng = rng or love.math.random
   if not encounterDef then return nil end
   local grass = encounterDef.grass
   if not grass or grass.rate == 0 then return nil end
-  if rng(0, 255) >= grass.rate then return nil end
+  local rate = rateOverride == nil and grass.rate or rateOverride
+  if rate <= 0 or rng(0, 255) >= rate then return nil end
   local pick = rng(0, 255)
   for i, threshold in ipairs(grass.buckets or buckets) do
     if pick < threshold then

--- a/src/world/OverworldController.lua
+++ b/src/world/OverworldController.lua
@@ -5065,7 +5065,9 @@ end
 
 -- the two vanilla links the encounter chains wrap, hoisted so an empty
 -- chain allocates no closure
-local function rollVanilla(encDef, ctx) return Encounter.roll(encDef, ctx.rng) end
+local function rollVanilla(encDef, ctx)
+  return Encounter.roll(encDef, ctx.rng, ctx.rateOverride)
+end
 local function sameEncounter(enc) return enc end
 
 -- The wild pick, wrapped in encounter.roll (returns nil to suppress, a
@@ -5073,11 +5075,18 @@ local function sameEncounter(enc) return enc end
 -- transforms a non-nil roll before repel filtering).  With no wrapper on
 -- either name this is the bare Encounter.roll, same RNG draws and all.
 function OverworldState:rollEncounter(encDef, terrain)
+  local rateOverride
+  local grass = encDef and encDef.grass
+  if grass then
+    local HeldItems = require("src.battle.HeldItems")
+    rateOverride = HeldItems.cleanseTagRate(Game.data, Game.save.party, grass.rate)
+  end
   if not (Runtime.wantsHook("encounter.roll")
           or Runtime.wantsHook("encounter.species")) then
-    return Encounter.roll(encDef)
+    return Encounter.roll(encDef, nil, rateOverride)
   end
-  local ctx = { mapId = self.map.id, terrain = terrain, rng = love.math.random }
+  local ctx = { mapId = self.map.id, terrain = terrain, rng = love.math.random,
+                rateOverride = rateOverride }
   local enc = Runtime.call("encounter.roll", rollVanilla, encDef, ctx)
   if enc then
     enc = Runtime.call("encounter.species", sameEncounter, enc, ctx)

--- a/tests/held_items_test.lua
+++ b/tests/held_items_test.lua
@@ -1,0 +1,280 @@
+-- Generation II held-item runtime regression tests.
+package.path = "./?.lua;./?/init.lua;" .. package.path
+love = love or require("tests.love_stub")
+
+local S = require("tests.harness").suite("gen2 held items")
+local check, eq = S.check, S.eq
+local HeldItems = require("src.battle.HeldItems")
+local TurnOrder = require("src.battle.TurnOrder")
+local Damage = require("src.battle.Damage")
+local Encounter = require("src.world.Encounter")
+local ruleset = require("src.battle.rulesets.gen1_faithful")
+
+local function item(key, effect, param)
+  return { key = key, heldEffect = effect or 0, heldParam = param or 0 }
+end
+
+local data = {
+  constants = { generation = 2 },
+  items = {
+    QUICK_CLAW = item("QUICK_CLAW", 74, 60),
+    BRIGHTPOWDER = item("BRIGHTPOWDER", 77, 20),
+    SCOPE_LENS = item("SCOPE_LENS", 73, 0),
+    STICK = item("STICK", 0, 0),
+    LUCKY_PUNCH = item("LUCKY_PUNCH", 0, 0),
+    THICK_CLUB = item("THICK_CLUB", 0, 0),
+    LIGHT_BALL = item("LIGHT_BALL", 0, 0),
+    METAL_POWDER = item("METAL_POWDER", 42, 10),
+    MYSTIC_WATER = item("MYSTIC_WATER", 59, 10),
+    DRAGON_SCALE = item("DRAGON_SCALE", 64, 10),
+    DRAGON_FANG = item("DRAGON_FANG", 0, 0),
+    FOCUS_BAND = item("FOCUS_BAND", 79, 30),
+    KINGS_ROCK = item("KING_S_ROCK", 75, 30),
+    LEFTOVERS = item("LEFTOVERS", 3, 10),
+    BERRY = item("BERRY", 1, 10),
+    GOLD_BERRY = item("GOLD_BERRY", 1, 30),
+    BERRY_JUICE = item("BERRY_JUICE", 1, 20),
+    PSNCUREBERRY = item("PSNCUREBERRY", 10, 0),
+    BITTER_BERRY = item("BITTER_BERRY", 16, 0),
+    MIRACLEBERRY = item("MIRACLEBERRY", 15, 0),
+    MYSTERYBERRY = item("MYSTERYBERRY", 6, -1),
+    LUCKY_EGG = item("LUCKY_EGG", 0, 0),
+    AMULET_COIN = item("AMULET_COIN", 76, 10),
+    SMOKE_BALL = item("SMOKE_BALL", 72, 0),
+    CLEANSE_TAG = item("CLEANSE_TAG", 8, 0),
+    BERSERK_GENE = item("BERSERK_GENE", 0, 0),
+  },
+  moves = { TACKLE = { pp = 35 }, SKETCH = { pp = 1 } },
+}
+
+local function mon(species, held, hp, maxhp)
+  hp, maxhp = hp or 100, maxhp or 100
+  return {
+    species = species or "EEVEE", item = held, hp = hp,
+    stats = { hp = maxhp }, moves = {}, status = nil,
+  }
+end
+
+local function battler(species, held, speed, hp, maxhp)
+  return {
+    mon = mon(species, held, hp, maxhp), species = species,
+    curStats = { attack = 100, defense = 100, speed = speed or 50,
+                 special = 100, spatk = 100, spdef = 100 },
+    curTypes = { "NORMAL" }, stages = { accuracy = 0, evasion = 0 },
+    isPlayer = true, name = species or "MON",
+  }
+end
+
+-- Quick Claw: priority still wins; equal priority checks serially and stops on
+-- the first successful holder instead of rolling both.
+do
+  local a = battler("EEVEE", "QUICK_CLAW", 10)
+  local b = battler("RATTATA", nil, 100)
+  local calls = 0
+  local rng = function() calls = calls + 1; return 0 end
+  check(TurnOrder.firstMover(a, { priority = 0 }, b, { priority = 0 }, rng, nil, data),
+        "Quick Claw can move a slower holder first")
+  eq(calls, 1, "Quick Claw consumes one roll when the first holder succeeds")
+  calls = 0
+  check(not TurnOrder.firstMover(a, { priority = 0 }, b, { priority = 1 }, rng, nil, data),
+        "Quick Claw never crosses move-priority classes")
+  eq(calls, 0, "different move priority does not roll Quick Claw")
+
+  local qa = battler("EEVEE", "QUICK_CLAW", 10)
+  local qb = battler("RATTATA", "QUICK_CLAW", 100)
+  calls = 0
+  check(TurnOrder.firstMover(qa, {}, qb, {}, rng, nil, data),
+        "first checked Quick Claw holder wins immediately")
+  eq(calls, 1, "two holders do not pre-roll both claws")
+end
+
+-- BrightPowder: a threshold can reach zero (no artificial 1/256 floor).
+do
+  local a, d = battler("EEVEE", nil), battler("RATTATA", "BRIGHTPOWDER")
+  local hit = Damage.accuracyRoll(ruleset, { accuracy = 100 }, a, d,
+    function() return 0 end, 10, data)
+  check(not hit, "BrightPowder may reduce the hit threshold to zero")
+end
+
+-- Gen II critical ladder plus held stages.
+do
+  local a = battler("EEVEE", "SCOPE_LENS")
+  local seenMax
+  local rng = function(lo, hi) seenMax = hi; return 31 end
+  check(Damage.critRoll(ruleset, a, "TACKLE", rng, false, data),
+        "Scope Lens raises base crit stage to 32/256")
+  eq(seenMax, 255, "Gen II crit uses a byte roll")
+
+  a = battler("FARFETCHD", "STICK")
+  check(Damage.critRoll(ruleset, a, "TACKLE", function() return 63 end, false, data),
+        "Stick gives Farfetch'd two crit stages")
+  a = battler("CHANSEY", "LUCKY_PUNCH")
+  check(Damage.critRoll(ruleset, a, "TACKLE", function() return 63 end, false, data),
+        "Lucky Punch gives Chansey two crit stages")
+end
+
+-- Species stat items and type boosters are data-driven.
+do
+  local a, d = battler("MAROWAK", "THICK_CLUB"), battler("DITTO", "METAL_POWDER")
+  local atk, def = HeldItems.modifyBattleStats(data, a, d, "attack", "defense", 100, 100)
+  eq(atk, 200, "Thick Club doubles Cubone/Marowak Attack")
+  eq(def, 150, "Metal Powder raises untransformed Ditto Defense by 50 percent")
+
+  a = battler("PIKACHU", "LIGHT_BALL")
+  atk = HeldItems.modifyBattleStats(data, a, battler("EEVEE"), "spatk", "spdef", 100, 100)
+  eq(atk, 200, "Light Ball doubles Pikachu Sp. Atk")
+
+  a = battler("VAPOREON", "MYSTIC_WATER")
+  eq(HeldItems.applyTypeBoost(data, a, "WATER", 101), 111,
+     "type booster applies x1.10 with its own floor")
+  -- The fixture deliberately keeps Crystal's raw ItemAttributes bug so this
+  -- verifies the recomp-level correction rather than hiding it in test data.
+  a.mon.item = "DRAGON_SCALE"
+  eq(HeldItems.applyTypeBoost(data, a, "DRAGON", 101), 101,
+     "Dragon Scale does not inherit Crystal's accidental Dragon boost")
+  a.mon.item = "DRAGON_FANG"
+  eq(HeldItems.applyTypeBoost(data, a, "DRAGON", 101), 111,
+     "Dragon Fang is corrected to boost Dragon-type damage")
+end
+
+-- Focus Band is a direct-damage guard; King's Rock is one held-effect roll.
+do
+  local d = battler("EEVEE", "FOCUS_BAND", 50, 40, 100)
+  eq(HeldItems.limitDirectDamage(data, d, 80, function() return 0 end), 39,
+     "Focus Band leaves a surviving holder at 1 HP")
+  eq(HeldItems.limitDirectDamage(data, d, 80, function() return 30 end), 80,
+     "Focus Band fails at/above its 30/256 threshold")
+
+  local u = battler("EEVEE", "KINGS_ROCK")
+  local t = battler("RATTATA", nil)
+  check(HeldItems.tryKingsRock(data, u, t, { effect = "NO_ADDITIONAL_EFFECT" },
+                               function() return 0 end, false),
+        "King's Rock can flinch on a NormalHit-script move")
+  check(t.flinched == true, "King's Rock sets flinch volatile")
+  t.flinched = nil
+  check(not HeldItems.tryKingsRock(data, u, t, { effect = "POISON_SIDE_EFFECT1" },
+                                   function() return 0 end, false),
+        "King's Rock skips move scripts that do not contain kingsrock")
+  check(HeldItems.tryKingsRock(data, u, t, { effect = "SNORE_EFFECT" },
+                               function() return 0 end, false),
+        "King's Rock still runs on Snore's native-flinch script")
+  t.flinched = nil
+  check(HeldItems.tryKingsRock(data, u, t, { id = "TRIPLE_KICK",
+        effect = "NO_ADDITIONAL_EFFECT", multiHit = 3 },
+        function() return 0 end, false),
+        "King's Rock runs after Triple Kick")
+  t.flinched = nil
+  check(not HeldItems.tryKingsRock(data, u, t, { effect = "NO_ADDITIONAL_EFFECT" },
+                                   function() return 0 end, true),
+        "King's Rock does not pass a Substitute")
+end
+
+-- Status/confusion consumables.
+do
+  local b = battler("EEVEE", "PSNCUREBERRY")
+  b.mon.status = "PSN"
+  local msgs = HeldItems.onStatus({ data = data }, b)
+  check(#msgs == 1 and b.mon.status == nil and b.mon.item == nil,
+        "PSNCUREBERRY immediately cures poison and is consumed")
+
+  b = battler("EEVEE", "BITTER_BERRY")
+  b.confusedTurns = 4
+  msgs = HeldItems.onConfusion({ data = data }, b)
+  check(#msgs == 1 and b.confusedTurns == nil and b.mon.item == nil,
+        "Bitter Berry immediately cures confusion")
+
+  b = battler("EEVEE", "MIRACLEBERRY")
+  b.mon.status = "BRN"
+  b.confusedTurns = 3
+  msgs = HeldItems.onStatus({ data = data }, b)
+  check(#msgs == 1 and b.mon.status == nil and b.confusedTurns == nil,
+        "MiracleBerry clears primary status and confusion together")
+end
+
+-- Weather/residual seam: an HP item can trigger after damage, but an already
+-- fainted battler is never revived.  Healing queues the real HP-bar target.
+do
+  local queue = {}
+  local battle = {
+    data = data, result = nil,
+    sayNext = function(_, text) queue[#queue + 1] = { text = text } end,
+    drainNext = function(_, who, hp) queue[#queue + 1] = { who = who, hp = hp } end,
+  }
+  battle.player = battler("EEVEE", "BERRY", 50, 49, 100)
+  battle.enemy = battler("RATTATA", nil, 50, 100, 100)
+  HeldItems.endTurn(battle)
+  eq(battle.player.mon.hp, 59, "Berry can trigger after residual damage crosses half HP")
+  check(battle.player.mon.item == nil, "healing Berry is consumed")
+  check(queue[#queue].hp == 59, "healing item queues HP-bar refresh to healed HP")
+
+  battle.player = battler("EEVEE", "LEFTOVERS", 50, 0, 100)
+  HeldItems.endTurn(battle)
+  eq(battle.player.mon.hp, 0, "Leftovers never revives a residual KO")
+end
+
+-- Berserk Gene, Lucky Egg, Amulet Coin, Smoke Ball and Cleanse Tag.
+do
+  local rngCalls = 0
+  local battle = {
+    data = data,
+    sayNext = function() end,
+    rng = function(lo, hi)
+      rngCalls = rngCalls + 1
+      eq(lo, 2, "Berserk Gene confusion roll uses the normal Gen II lower bound")
+      eq(hi, 5, "Berserk Gene confusion roll uses the normal Gen II upper bound")
+      return 4
+    end,
+  }
+  local b = battler("EEVEE", "BERSERK_GENE")
+  check(HeldItems.onEntry(battle, b), "Berserk Gene activates on entry")
+  eq(b.stages.attack, 2, "Berserk Gene raises Attack two stages")
+  eq(b.confusedTurns, 4, "Berserk Gene initializes a normal confusion duration")
+  eq(HeldItems.confusionCounter(battle, b), 4, "Berserk Gene stores the new side confusion counter")
+  eq(rngCalls, 1, "Berserk Gene rolls confusion duration exactly once")
+  check(b.mon.item == nil, "Berserk Gene is consumed")
+
+  battle = {
+    data = data,
+    sayNext = function() end,
+    heldConfusionCounters = { player = 3 },
+    rng = function(lo, hi)
+      eq(lo, 2, "corrected Berserk Gene reroll lower bound")
+      eq(hi, 5, "corrected Berserk Gene reroll upper bound")
+      return 5
+    end,
+  }
+  b = battler("EEVEE", "BERSERK_GENE")
+  HeldItems.onEntry(battle, b)
+  eq(b.confusedTurns, 5, "Berserk Gene replaces a stale same-side confusion counter")
+  eq(HeldItems.confusionCounter(battle, b), 5, "Berserk Gene stores the fresh confusion counter")
+
+  local egg = mon("CHANSEY", "LUCKY_EGG")
+  eq(HeldItems.modifyExperience(data, egg, 100), 150, "Lucky Egg gives x1.5 EXP")
+
+  battle = { data = data }
+  b = battler("MEOWTH", "AMULET_COIN")
+  HeldItems.observeParticipant(battle, b)
+  eq(HeldItems.modifyPrize(battle, 1000), 2000,
+     "Amulet Coin doubles prize after its holder participates")
+
+  b = battler("EEVEE", "SMOKE_BALL")
+  check(HeldItems.canEscape(data, b), "Smoke Ball guarantees wild escape")
+
+  local party = { mon("EEVEE", "CLEANSE_TAG"), mon("RATTATA") }
+  eq(HeldItems.cleanseTagRate(data, party, 25), 12,
+     "Cleanse Tag halves the encounter-rate byte with floor")
+  party = { mon("EEVEE"), mon("RATTATA", "CLEANSE_TAG") }
+  eq(HeldItems.cleanseTagRate(data, party, 25), 12,
+     "Cleanse Tag works from any occupied party slot")
+end
+
+-- Encounter.roll applies an already-adjusted rate before the slot RNG.
+do
+  local calls = 0
+  local enc = { grass = { rate = 25, buckets = { 256 }, slots = { { species = "RATTATA", level = 2 } } } }
+  local got = Encounter.roll(enc, function() calls = calls + 1; return calls == 1 and 12 or 0 end, 12)
+  check(got == nil, "halved encounter rate rejects roll equal to threshold")
+  eq(calls, 1, "failed rate check consumes no encounter-slot roll")
+end
+
+S.finish()


### PR DESCRIPTION
## Summary

Adds a centralized Gen II held-item runtime across battle, experience,
encounters, trainer data, and link behavior.

Implemented mechanics include:

- Quick Claw
- type-boosting held items
- Thick Club, Light Ball, Metal Powder
- Scope Lens, Stick, Lucky Punch
- BrightPowder
- King's Rock
- Focus Band
- Berserk Gene
- Leftovers
- Berry / Gold Berry / Berry Juice
- status-curing berries
- MysteryBerry
- Lucky Egg
- Amulet Coin
- Smoke Ball
- Cleanse Tag
- wild held-item generation
- trainer / Battle Tower held items
- link-related held-item propagation

## Intentional legacy fixes

Two known Gen II retail issues are intentionally corrected:

- Dragon Fang correctly boosts Dragon-type moves instead of reproducing the Dragon Scale mapping bug.
- Berserk Gene initializes a normal confusion duration instead of preserving the stale/256-turn confusion-counter bug.

Both corrections were discussed and agreed before submission.

## Tests

Adds regression coverage for the held-item runtime, including the
Dragon Fang and Berserk Gene corrections.