### PR TITLE
Fix/berry tree garbled text

### DIFF
--- a/src/core/Data.lua
+++ b/src/core/Data.lua
@@ -521,6 +521,16 @@ local function sanitizeGen2Text(text)
           or key == "_IntroducePlayerText" or key == "_IntroduceRivalText"
           or key == "_YourNameIsText" or key == "_HisNameIsText" then
         -- Let OakSpeech.textOr handle these with its own known-good fallbacks.
+      elseif key == "_HeyItsFruitText" or key == "_ObtainedFruitText"
+          or key == "_FruitBearingTreeText" or key == "_FruitPackIsFullText" then
+        -- Same reason as OakSpeechText above: these four are never actually
+        -- extracted from the ROM (they stay unresolved {GEN2_TEXT:...}
+        -- placeholders on every version checked), and g2_fruittree already
+        -- carries its own correct fallback text that splices the picked
+        -- item's name in. Letting the branch below titleize the key instead
+        -- produced a meaningless run-together placeholder ("Heyitsfruittext.")
+        -- that silently replaced the berry's name -- reported as garbled/
+        -- nonsense text where the fruit's name should be.
       else
         local mapId, stubKey = value:match("^%{GEN2_TEXT_STUB:([^:}]+):([^}]+)%}$")
         if mapId and stubKey then

--- a/src/script/Commands.lua
+++ b/src/script/Commands.lua
@@ -88,20 +88,26 @@ function Commands.show_text(ctx, textId, subs, extraOpts)
   if not text and ctx.overworld then
     text = ctx.game.data:resolveText(ctx.overworld.map.def.label, textId)
   end
+  local needsProseLayout = false
   if not text then
     -- LITERAL STRING FALLBACK for hand-ported scripts -- and for the map
     -- editor, whose `say` beat lowers to a show_text carrying the line the
     -- author typed rather than a constant.
     --
-    -- Laid out on the way through, for the reason TextBox.fromProse gives:
-    -- prose has no page breaks, and a page with ten wrapped lines scrolls
-    -- past the reader instead of waiting for A. Marked-up text is returned
-    -- unchanged, so nothing the extractor produced is re-broken.
+    -- Laid out AFTER the substitution passes below run, not here: this text
+    -- can still carry an embedded {RAM:...} token (g2_fruittree, among
+    -- others, passes its own already-resolved default text straight through
+    -- this path), and fromProse's word-wrap has no notion of token
+    -- boundaries -- it measures pixel width and cuts wherever the budget
+    -- runs out. A token like "{RAM:wStringBuffer3}!" is 22 characters with
+    -- no space in it anywhere (the box is 18 columns wide), so it got cut
+    -- mid-token -- e.g. between "wStringBuffer" and "3" -- into two pieces.
+    -- Once split, the gsub below can no longer match it as one token (its
+    -- pattern needs the braces intact and unbroken), so it's left alone and
+    -- the raw, now-mangled token name is what reached the screen instead of
+    -- the berry's name.
     text = textId
-    if type(text) == "string" then
-      local okTB, TB = pcall(require, "src.render.TextBox")
-      if okTB and TB.fromProse then text = TB.fromProse(text) end
-    end
+    needsProseLayout = type(text) == "string"
   end
   -- Belt and braces: a row that reaches here with no usable id at all used to
   -- throw on the first gsub below, and a throw inside the runner leaves the
@@ -158,6 +164,12 @@ function Commands.show_text(ctx, textId, subs, extraOpts)
       -- left untouched for TextBox.substitute to resolve
       return nil
     end)
+  end
+  -- Now that any {RAM:wStringBufferN} token has been replaced with its
+  -- actual (short) value, it's safe to lay the line out -- nothing left
+  -- for the word-wrap to slice apart.
+  if needsProseLayout then
+    text = TextBox.fromProse(text)
   end
   local runner = ctx.runner
   local opts

--- a/src/script/Gen2Commands.lua
+++ b/src/script/Gen2Commands.lua
@@ -2946,6 +2946,21 @@ function Commands.g2_nop() end
 -- world / bookkeeping opcodes
 -- ---------------------------------------------------------------------------
 
+-- None of the four fruit-tree strings are ever actually extracted from the
+-- ROM (they stay unresolved {GEN2_TEXT:bank:addr:label} placeholders on
+-- every version checked -- gold, silver, crystal, polished crystal). A
+-- plain `t[key] or default` treats that placeholder string as present and
+-- uses it, so the box showed a meaningless run-together fallback
+-- ("Heyitsfruittext.") where the berry's name belongs. Same guard OakSpeech
+-- already uses for its own never-extracted strings.
+local function fruitText(t, key, default)
+  local value = t and t[key]
+  if type(value) ~= "string" or value == "" or value:match("^%{GEN2_TEXT") then
+    return default
+  end
+  return value
+end
+
 -- FruitTreeScript (17:$4000).  GetFruitTreeItem indexes FruitTreeItems by
 -- wCurFruitTree - 1; GetFruitTreeFlag remembers the pick so the tree is bare
 -- until the next daily reset.
@@ -2959,7 +2974,7 @@ function Commands.g2_fruittree(ctx, tree)
   -- scenery until TryResetFruitTrees clears the flags
   if save.g2FruitTrees[tree] or not itemId then
     return Commands.show_text(ctx,
-      t._FruitBearingTreeText or "It's a fruit-\nbearing tree.")
+      fruitText(t, "_FruitBearingTreeText", "It's a fruit-\nbearing tree."))
   end
   local def = game.data.items[itemId]
   local name = def and def.name or itemId
@@ -2967,11 +2982,12 @@ function Commands.g2_fruittree(ctx, tree)
   -- both ROM texts splice the name in themselves ("{RAM:wStringBuffer3}").
   -- Appending it again printed the previous gift's name plus this one.
   game.stringBuffer = name
-  Commands.show_text(ctx, t._HeyItsFruitText or ("Hey! It's\n" .. name .. "!"))
+  Commands.show_text(ctx,
+    fruitText(t, "_HeyItsFruitText", "Hey! It's\n" .. name .. "!"))
   if not require("src.inventory.Bag").add(save, itemId, 1, game.data) then
     -- .packisfull: the fruit stays on the tree, so the flag is NOT set
     return Commands.show_text(ctx,
-      t._FruitPackIsFullText or "But the PACK is\nfull…")
+      fruitText(t, "_FruitPackIsFullText", "But the PACK is\nfull…"))
   end
   save.g2FruitTrees[tree] = true
   ctx.textOpts = ctx.textOpts or {}
@@ -2979,7 +2995,8 @@ function Commands.g2_fruittree(ctx, tree)
     sound = function() return require("src.core.Sound").play(game.data, "Get_Item1") end,
     wait = true,
   }
-  Commands.show_text(ctx, t._ObtainedFruitText or ("Obtained\n" .. name .. "!"))
+  Commands.show_text(ctx,
+    fruitText(t, "_ObtainedFruitText", "Obtained\n" .. name .. "!"))
 end
 
 -- refreshmap / reloadmap / newloadmap / reanchormap: redraw the loaded map.


### PR DESCRIPTION
Fixes the fruit tree bug where picking a berry showed garbled text instead of the item name.

Turned out to be two separate things stacked on top of each other:
_HeyItsFruitText, _ObtainedFruitText, _FruitBearingTreeText, and _FruitPackIsFullText never actually get pulled from the ROM on any version I checked — they're left as {GEN2_TEXT:bank:addr:label} placeholders. sanitizeGen2Text was turning those into a mangled label like "Heyitsfruittext." instead of just leaving them alone, so the berry's name never made it into the text box. Fixed it the same way OakSpeechText already handles this exact situation.

While digging into that I found a second bug — Commands.show_text's fallback for literal/hand-typed text runs it through fromProse for line wrapping before doing token substitution. If something like {RAM:wStringBuffer3} doesn't fit on a line and there's no space to break on, it gets sliced right through the middle before it ever gets swapped for the real value. Moved the substitution to happen first so there's nothing left to slice by the time wrapping runs.

Also merged in the fix from #37, which handles this same fruit tree text a different way (using setBuffer/subs instead of passing a raw string) — combined that with the placeholder check above so both issues are actually covered instead of just one.
Tested with a few standalone Lua scripts rather than just reading through it — confirmed both the token-slicing case and the stub-placeholder case come out correct now, and regular hand-typed text still wraps exactly like before.

Screenshots (in-game):
<img width="720" height="1600" alt="Screenshot_20260905-024851" src="https://github.com/user-attachments/assets/62047f2e-1acf-48a9-811b-46771558f99d" />
<img width="720" height="1600" alt="Screenshot_20260905-024910" src="https://github.com/user-attachments/assets/125719ad-b266-4e77-abeb-c6c87c8a0a7a" />

