### PR TITLE
Complete Gen II held-item generation and propagation

### DIFF
--- a/src/battle/BattleState.lua
+++ b/src/battle/BattleState.lua
@@ -774,6 +774,10 @@ function BattleState.newWild(game, species, level, opts)
     self.player = makeBattler(game.data, playerMon, true, game.save)
   end
   local wild = Pokemon.new(game.data, species, level)
+  if game.data and game.data.constants and game.data.constants.generation == 2 then
+    wild.item = HeldItems.rollWild(
+      game.data, species, self.rng, opts and opts.forceCommonItem)
+  end
   -- BATTLETYPE_SHINY (`loadvar 3, 7` before the loadwildmon) overwrites the
   -- rolled DVs with the fixed shiny pair; the Lake of Rage Gyarados is the
   -- only encounter in Gold that uses it.
@@ -891,6 +895,9 @@ function BattleState.newTrainer(game, oppClass, partyIndex)
   self.enemyParty = {}
   for _, slot in ipairs(partyDef) do
     local mon = Pokemon.new(game.data, slot.species, slot.level)
+    -- TrainerGroups item-bearing party formats and BattleTowerMons already
+    -- expose the cartridge item as slot.item; preserve it on the runtime mon.
+    mon.item = slot.item
     -- fixed trainer DVs, recomputed stats.  A party slot that carries its OWN
     -- DVs and stat exp is a stored mon rather than a generated one -- the
     -- Battle Tower's opponents come out of BattleTowerMons with both -- so its

--- a/src/battle/HeldItems.lua
+++ b/src/battle/HeldItems.lua
@@ -134,6 +134,21 @@ local function consume(holder)
 end
 HeldItems.consume = consume
 
+-- LoadEnemyMon .WildItem (Gen II): normal wild encounters first have a
+-- 75% no-item branch, then use a second byte to choose Item2 for 8% of the
+-- remaining 25%. BATTLETYPE_FORCEITEM bypasses both rolls and uses Item1.
+function HeldItems.rollWild(data, species, rng, forceCommon)
+  local def = data and data.pokemon and data.pokemon[species]
+  local common = def and def.heldItemCommon or nil
+  local rare = def and def.heldItemRare or nil
+  if forceCommon then return common end
+
+  rng = rng or love.math.random
+  if rng(0, 255) < 192 then return nil end
+  if rng(0, 255) < 20 then return rare end
+  return common
+end
+
 local function isAlive(holder)
   local mon = monOf(holder)
   return mon and (tonumber(mon.hp) or 0) > 0

--- a/src/import/RomExtractorGen2.lua
+++ b/src/import/RomExtractorGen2.lua
@@ -4015,6 +4015,9 @@ function RomExtractorGen2:extractPokemon()
   local typesAt = self:layout("baseTypesAt", 8)
   local catchAt = self:layout("baseCatchAt", 10)
   local expAt = self:layout("baseExpAt", 11)
+  -- Item1/Item2 immediately follow base EXP in Crystal/Gold and in the
+  -- supported compact layouts; keep the offset manifest-overridable.
+  local itemsAt = self:layout("baseItemsAt", expAt + 1)
   local genderAt = self:layout("baseGenderAt", RomExtractorGen2.GEN2_BASE_GENDER)
   -- polished packs gender (high nibble) and hatch cycles (low nibble) into
   -- ONE byte; see GetGenderRatio (00:$3214) / the egg-steps math (03:$5d60)
@@ -4034,6 +4037,7 @@ function RomExtractorGen2:extractPokemon()
     local hp, atk, def, spd, satk, sdef = 45, 49, 49, 45, 65, 65
     local type1, type2 = "NORMAL", "NORMAL"
     local catchRate, baseExp = 45, 64
+    local heldItemCommon, heldItemRare
     local growthRate = "MEDIUM_FAST"
     local picDims = 0x77  -- default 7x7; overwritten from BaseData below
     local tmhm = {}
@@ -4056,6 +4060,12 @@ function RomExtractorGen2:extractPokemon()
         type1 = self:gen2TypeName(entry[typesAt]) or "NORMAL"
         type2 = self:gen2TypeName(entry[typesAt + 1]) or type1
         catchRate = entry[catchAt]; baseExp = entry[expAt]
+        if #entry >= itemsAt + 1 then
+          local common = entry[itemsAt] or 0
+          local rare = entry[itemsAt + 1] or 0
+          heldItemCommon = common > 0 and string.format("ITEM_%03d", common) or nil
+          heldItemRare = rare > 0 and string.format("ITEM_%03d", rare) or nil
+        end
         growthRate = GEN2_GROWTH_RATES[entry[growthAt]] or growthRate
       end
       if ok and type(entry) == "table" and #entry >= ENTRY then
@@ -4238,6 +4248,7 @@ function RomExtractorGen2:extractPokemon()
         special = satk, spatk = satk, spdef = sdef,
       },
       catchRate = catchRate, baseExp = baseExp, growthRate = growthRate,
+      heldItemCommon = heldItemCommon, heldItemRare = heldItemRare,
       tmhm = tmhm,
       -- breeding (base_stats bytes 14/16/24): DayCare.compatibility needs
       -- the real groups and gender split, and Gen2Commands' giveegg needs

--- a/src/import/RomImporter.lua
+++ b/src/import/RomImporter.lua
@@ -345,7 +345,10 @@ end
 -- (09:$72b5) instead of Crystal's static table -- Growl's effect byte $39 was
 -- Crystal's TRANSFORM_EFFECT, so status/stat moves misfired ("used Growl,
 -- transformed into Cyndaquil"); moves.lua changes for every affected move.
-local CACHE_FORMAT = "rom-cache-v81:"
+--
+-- v82: Gen2 BaseData now exports Item1/Item2 on each Pokemon record so wild
+-- encounter generation can reproduce cartridge held items; pokemon.lua changes.
+local CACHE_FORMAT = "rom-cache-v82:"
 -- The completion marker is written under each version's cache prefix
 -- (rom-cache.complete for Red, blue/rom-cache.complete for Blue).
 local MARKER_PATH = "rom-cache.complete"

--- a/src/script/Gen2Commands.lua
+++ b/src/script/Gen2Commands.lua
@@ -1196,8 +1196,11 @@ function Commands.g2_start_battle(ctx)
   ctx.g2BattleType = nil
   if wild then
     ctx.g2Wild = nil
-    Commands.start_battle(ctx, "wild", wild.species, wild.level,
-      { shiny = battleType == Commands.G2_BATTLETYPE_SHINY })
+    Commands.start_battle(ctx, "wild", wild.species, wild.level, {
+      shiny = battleType == Commands.G2_BATTLETYPE_SHINY,
+      forceCommonItem = battleType == Commands.G2_BATTLETYPE_FORCEITEM,
+      battleType = battleType,
+    })
   elseif trainer then
     -- winlosstext's first pointer is the beaten trainer's own line, and
     -- TrainerBattleVictory prints it ON the battle screen just before
@@ -2156,10 +2159,12 @@ function Commands.g2_writevar(ctx, var)
   end
 end
 
--- `loadvar 3, n` writes wBattleType ($D119).  BATTLETYPE_SHINY is 7; the
--- byte is consumed by the next startbattle and cleared with the rest of the
--- battle variables afterwards, so it is deliberately NOT saved.
+-- `loadvar 3, n` writes wBattleType ($D119). BATTLETYPE_SHINY is 7 and
+-- BATTLETYPE_FORCEITEM is 10; the byte is consumed by the next startbattle
+-- and cleared with the rest of the battle variables afterwards, so it is
+-- deliberately NOT saved.
 Commands.G2_BATTLETYPE_SHINY = 7
+Commands.G2_BATTLETYPE_FORCEITEM = 10
 
 function Commands.g2_loadvar(ctx, var, value)
   if var == 3 then ctx.g2BattleType = tonumber(value) or 0 end

--- a/tests/held_items_test.lua
+++ b/tests/held_items_test.lua
@@ -45,6 +45,10 @@ local data = {
     BERSERK_GENE = item("BERSERK_GENE", 0, 0),
   },
   moves = { TACKLE = { pp = 35 }, SKETCH = { pp = 1 } },
+  pokemon = {
+    SENTRET = { heldItemCommon = "BERRY", heldItemRare = "GOLD_BERRY" },
+    EEVEE = {},
+  },
 }
 
 local function mon(species, held, hp, maxhp)
@@ -277,4 +281,41 @@ do
   eq(calls, 1, "failed rate check consumes no encounter-slot roll")
 end
 
+-- Wild held-item generation: byte boundaries, RNG consumption and
+-- BATTLETYPE_FORCEITEM match LoadEnemyMon's Gen II item-selection path.
+do
+  local function run(species, rolls, forceCommon)
+    local index = 0
+    local rng = function(lo, hi)
+      eq(lo, 0, "wild item RNG lower byte bound")
+      eq(hi, 255, "wild item RNG upper byte bound")
+      index = index + 1
+      local value = rolls[index]
+      if value == nil then error("unexpected wild-item RNG call " .. tostring(index)) end
+      return value
+    end
+    local got = HeldItems.rollWild(data, species, rng, forceCommon)
+    return got, index
+  end
+
+  local got, calls = run("SENTRET", { 191 }, false)
+  eq(got, nil, "0..191 chooses no held item")
+  eq(calls, 1, "no-item branch consumes one byte roll")
+
+  got, calls = run("SENTRET", { 192, 19 }, false)
+  eq(got, "GOLD_BERRY", "second roll 0..19 chooses rare Item2")
+  eq(calls, 2, "item branch consumes two byte rolls")
+
+  got, calls = run("SENTRET", { 192, 20 }, false)
+  eq(got, "BERRY", "second roll 20..255 chooses common Item1")
+  eq(calls, 2, "common branch consumes two byte rolls")
+
+  got, calls = run("SENTRET", {}, true)
+  eq(got, "BERRY", "BATTLETYPE_FORCEITEM chooses Item1")
+  eq(calls, 0, "BATTLETYPE_FORCEITEM consumes no item RNG")
+
+  got, calls = run("EEVEE", { 192, 0 }, false)
+  eq(got, nil, "a species with empty item slots still yields no item")
+  eq(calls, 2, "empty item slots still follow the normal item RNG path")
+end
 S.finish()


### PR DESCRIPTION
## Summary

Follow-up to #42 completing the Gen II held-item data paths that were not part of the battle-runtime implementation.

This PR:

- extracts each species' BaseData Item1 / Item2 fields;
- reproduces Gen II wild held-item generation;
- propagates `BATTLETYPE_FORCEITEM` for scripted encounters;
- preserves held items on trainer party Pokémon;
- preserves Battle Tower held items through the existing trainer construction path;
- bumps the ROM cache format from v81 to v82 so existing imports regenerate the new species data;
- adds regression coverage for wild held-item selection.

## Gen II wild item behavior

Normal wild encounters follow the cartridge byte checks:

- first roll `< 192`: no item;
- otherwise second roll `< 20`: Item2;
- otherwise: Item1.

Effective probabilities are therefore:

- 75% no item;
- 23.046875% Item1;
- 1.953125% Item2.

`BATTLETYPE_FORCEITEM` bypasses the random item selection and uses Item1, matching the scripted Gen II behavior used for encounters such as Ho-Oh, Lugia and Snorlax.

## Trainer / Battle Tower

Trainer-group and Battle Tower extraction already expose held-item information on party slots.

This PR completes the runtime path by preserving `slot.item` when the opponent Pokémon is constructed.

## Cache

The ROM cache format is bumped to `rom-cache-v82` because generated Pokémon BaseData now includes the two held-item fields.

## Validation

- `git diff --check` passes.
- `luajit tests/held_items_test.lua`
- **75/75 checks passed**

## Scope

This deliberately does not duplicate the held-item battle runtime merged in #42.

Link Trade held-item serialization is also outside this PR because it was already handled separately in #32.